### PR TITLE
# Implement unique game pin generation (closes #44)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
     // Provides the documentation API

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Session.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Session.java
@@ -2,18 +2,21 @@ package ch.uzh.ifi.hase.soprafs26.entity;
 
 import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
 
-import java.io.Serializable;
-import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.time.LocalDateTime;
-import java.util.Set;
 import java.util.HashSet;
+import java.util.Set;
 
+@Setter
+@Getter
 @Entity
 @Table(name = "sessions")
 public class Session {
+
+    // getters and setters via Lombok
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,6 +36,7 @@ public class Session {
     private SessionStatus status = SessionStatus.CREATED;
 
     @Column(nullable = false, updatable = false)
+    @CreationTimestamp
     private LocalDateTime createdAt;
 
 
@@ -54,20 +58,6 @@ public class Session {
     )
 
     private Set<User> participants = new HashSet<>();
-
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        if (this.gamePin == null) {
-            this.gamePin = generateGamePin();
-        }
-    }
-
-    public String generateGamePin() {
-        // 6-digit random PIN
-        int pin = (int)(Math.random() * 900_000) + 100_000;
-        return String.valueOf(pin);
-    }
 
     public void start() {
         this.status = SessionStatus.ACTIVE;
@@ -97,30 +87,5 @@ public class Session {
         this.participants.remove(user);
     }
 
-
-    // getters and setters
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
-
-    public String getName() { return name; }
-    public void setName(String name) { this.name = name; }
-
-    public String getDescription() { return description; }
-    public void setDescription(String description) { this.description = description; }
-
-    public String getGamePin() { return gamePin; }
-    public void setGamePin(String gamePin) { this.gamePin = gamePin; }
-
-    public SessionStatus getStatus() { return status; }
-    public void setStatus(SessionStatus status) { this.status = status; }
-
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
-
-    public User getAdmin() { return admin; }
-    public void setAdmin(User admin) { this.admin = admin; }
-
-    public Set<User> getParticipants() { return participants; }
-    public void setParticipants(Set<User> participants) { this.participants = participants; }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/SessionRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/SessionRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository("sessionRepository")
 public interface SessionRepository extends JpaRepository<Session, Long> {
     Session findByGamePin(String gamePin);
+
+    boolean existsByGamePin(String gamePin);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -2,24 +2,19 @@ package ch.uzh.ifi.hase.soprafs26.service;
 
 import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionPostDTO;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
-import ch.uzh.ifi.hase.soprafs26.entity.User;
-import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Set;
-
-import java.time.OffsetDateTime;
-import java.util.Random;
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -48,11 +43,18 @@ public class SessionService {
         session.setAdmin(admin);
         // Admin is automatically a participant of their own session
         session.addParticipant(admin);
+
+        String gamePin;
+        do {
+            gamePin = UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+        } while (sessionRepository.existsByGamePin(gamePin));
+
+        session.setGamePin(gamePin);
+
         Session saved = sessionRepository.save(session);
         log.debug("Created session {} with admin {}", saved.getId(), admin.getId());
         return saved;
     }
-
 
     public Session getSessionById(Long sessionId) {
         return sessionRepository.findById(sessionId)

--- a/src/main/resources/static/karaokee-openapi.json
+++ b/src/main/resources/static/karaokee-openapi.json
@@ -835,13 +835,6 @@
       }
     },
     "schemas": {
-      "UserStatus": {
-        "type": "string",
-        "enum": [
-          "ONLINE",
-          "OFFLINE"
-        ]
-      },
       "SessionStatus": {
         "type": "string",
         "enum": [
@@ -907,9 +900,6 @@
           },
           "username": {
             "type": "string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/UserStatus"
           }
         }
       },
@@ -926,9 +916,6 @@
           "token": {
             "type": "string",
             "format": "uuid"
-          },
-          "status": {
-            "$ref": "#/components/schemas/UserStatus"
           }
         }
       },

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionsControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionsControllerTest.java
@@ -1,0 +1,130 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.Session;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionPostDTO;
+import ch.uzh.ifi.hase.soprafs26.service.SessionService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SessionsController.class)
+class SessionsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SessionService sessionService;
+
+    @MockitoBean
+    private UserService userService;
+
+    private User admin;
+    private Session session;
+
+    @BeforeEach
+    void setUp() {
+        admin = new User();
+        admin.setId(1L);
+        admin.setUsername("adminUser");
+        admin.setToken("valid-token");
+
+        session = new Session();
+        session.setId(10L);
+        session.setName("Friday Night Karaoke");
+        session.setDescription("Fun session");
+        session.setGamePin("a1b2c3");
+        session.setStatus(SessionStatus.CREATED);
+        session.setAdmin(admin);
+        session.addParticipant(admin);
+    }
+
+    @Test
+    void sessionsPost_validToken_returns201WithBody() throws Exception {
+        SessionPostDTO body = new SessionPostDTO();
+        body.setName("Friday Night Karaoke");
+        body.setDescription("Fun session");
+
+        given(userService.getUserByToken("valid-token")).willReturn(admin);
+        given(sessionService.createSession(eq("Friday Night Karaoke"), eq("Fun session"), eq(admin)))
+                .willReturn(session);
+
+        mockMvc.perform(post("/sessions")
+                        .header("token", "valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(body)))
+                .andExpect(status().isCreated())
+                // top-level SessionGetDTO fields
+                .andExpect(jsonPath("$.id", is(10)))
+                .andExpect(jsonPath("$.name", is("Friday Night Karaoke")))
+                .andExpect(jsonPath("$.description", is("Fun session")))
+                .andExpect(jsonPath("$.gamePin", is("a1b2c3")))
+                .andExpect(jsonPath("$.status", is("CREATED")))
+                // admin sub-object (spec: UserGetDTO with id + username)
+                .andExpect(jsonPath("$.admin.id", is(1)))
+                .andExpect(jsonPath("$.admin.username", is("adminUser")))
+                // participants array — admin is auto-added on creation
+                .andExpect(jsonPath("$.participants", hasSize(1)))
+                .andExpect(jsonPath("$.participants[0].id", is(1)))
+                .andExpect(jsonPath("$.participants[0].username", is("adminUser")));
+    }
+
+    @Test
+    void sessionsPost_missingToken_returns401() throws Exception {
+        SessionPostDTO body = new SessionPostDTO();
+        body.setName("Friday Night Karaoke");
+
+        given(userService.getUserByToken(any()))
+                .willThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing authentication token"));
+
+        mockMvc.perform(post("/sessions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(body)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void sessionsPost_invalidToken_returns401() throws Exception {
+        SessionPostDTO body = new SessionPostDTO();
+        body.setName("Friday Night Karaoke");
+
+        given(userService.getUserByToken("bad-token"))
+                .willThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid or expired token"));
+
+        mockMvc.perform(post("/sessions")
+                        .header("token", "bad-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(body)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private String asJsonString(final Object object) {
+        try {
+            return new ObjectMapper().writeValueAsString(object);
+        }
+        catch (JacksonException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format("The request body could not be created.%s", e));
+        }
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceIntegrationTest.java
@@ -1,0 +1,80 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.Session;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@WebAppConfiguration
+@SpringBootTest
+@Transactional
+class SessionServiceIntegrationTest {
+
+    @Qualifier("sessionRepository")
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @Qualifier("userRepository")
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private SessionService sessionService;
+
+    private User admin;
+
+    @BeforeEach
+    void setup() {
+        sessionRepository.deleteAll();
+        userRepository.deleteAll();
+
+        admin = new User();
+        admin.setUsername("adminUser");
+        admin.setPassword("password");
+        admin.setToken("admin-token-uuid");
+        admin = userRepository.save(admin);
+    }
+
+    @Test
+    void createSession_validInputs_persistedCorrectly() {
+        Session created = sessionService.createSession("Friday Night Karaoke", "Fun session", admin);
+
+        assertNotNull(created.getId());
+        assertEquals("Friday Night Karaoke", created.getName());
+        assertEquals("Fun session", created.getDescription());
+        assertEquals(SessionStatus.CREATED, created.getStatus());
+        assertNotNull(created.getGamePin());
+        assertEquals(6, created.getGamePin().length());
+        assertNotNull(created.getCreatedAt());
+        assertEquals(admin.getId(), created.getAdmin().getId());
+    }
+
+    @Test
+    void createSession_adminIsParticipant_persistedInJoinTable() {
+        Session created = sessionService.createSession("Test Session", null, admin);
+
+        Session fetched = sessionRepository.findById(created.getId()).orElseThrow();
+        assertTrue(fetched.getParticipants().stream()
+                        .anyMatch(u -> u.getId().equals(admin.getId())),
+                "Admin must appear in the persisted participants join table");
+    }
+
+    @Test
+    void createSession_twoSessions_haveDistinctGamePins() {
+        Session first = sessionService.createSession("Session One", null, admin);
+        Session second = sessionService.createSession("Session Two", null, admin);
+
+        assertNotEquals(first.getGamePin(), second.getGamePin(),
+                "Each session must receive a unique game pin");
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -59,6 +59,66 @@ class SessionServiceTest {
     }
 
 
+    // createSession
+
+    @Test
+    void createSession_validInput_returnsPersistedSession() {
+        when(sessionRepository.existsByGamePin(any())).thenReturn(false);
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> {
+            Session s = i.getArgument(0);
+            s.setId(10L);
+            return s;
+        });
+
+        Session result = sessionService.createSession("Friday Night Karaoke", "Fun session", admin);
+
+        assertNotNull(result);
+        assertEquals("Friday Night Karaoke", result.getName());
+        assertEquals("Fun session", result.getDescription());
+        assertEquals(admin, result.getAdmin());
+        assertNotNull(result.getGamePin());
+        assertEquals(6, result.getGamePin().length());
+        verify(sessionRepository, times(1)).save(any(Session.class));
+    }
+
+    @Test
+    void createSession_adminIsAddedAsParticipant() {
+        when(sessionRepository.existsByGamePin(any())).thenReturn(false);
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        Session result = sessionService.createSession("Test Session", null, admin);
+
+        assertTrue(result.getParticipants().contains(admin),
+                "Admin must be automatically added as a participant");
+    }
+
+    @Test
+    void createSession_defaultStatusIsCreated() {
+        when(sessionRepository.existsByGamePin(any())).thenReturn(false);
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        Session result = sessionService.createSession("Test Session", null, admin);
+
+        assertEquals(SessionStatus.CREATED, result.getStatus());
+    }
+
+    @Test
+    void createSession_pinCollision_retriesUntilUnique() {
+        // First generated pin collides, second is unique
+        when(sessionRepository.existsByGamePin(any()))
+                .thenReturn(true)
+                .thenReturn(false);
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        Session result = sessionService.createSession("Test Session", null, admin);
+
+        assertNotNull(result.getGamePin());
+        // existsByGamePin must have been called at least twice
+        verify(sessionRepository, atLeast(2)).existsByGamePin(any());
+        verify(sessionRepository, times(1)).save(any(Session.class));
+    }
+
+
     // joinSession
 
     @Test


### PR DESCRIPTION
  ## Implementation:
  - Move game pin generation from Session entity to SessionService.createSession()
  - Generate 6-char alphanumeric pin via UUID; retry in a loop until SessionRepository.existsByGamePin() confirms uniqueness
  - Replace @PrePersist with @CreationTimestamp on Session.createdAt;add Lombok @Getter/@Setter to Session entity

  ## Tests:
  - SessionServiceTest: 4 unit tests for createSession (happy path, admin auto-added as participant, default CREATED status, pin collision retry)
  - SessionsControllerTest: 3 slice tests for POST /sessions (201 with full SessionGetDTO body, missing token → 401, invalid token → 401)
  - SessionServiceIntegrationTest: 3 integration tests (fields persisted correctly incl. createdAt, admin in join table, two sessions get distinct pins) ## Unrelated fixes:
  - build.gradle: add annotationProcessor for Lombok and lombok-mapstruct-binding so MapStruct can see Lombok-generated getters/setters (was silently failing)
  - SessionServiceIntegrationTest: annotate with @Transactional to prevent LazyInitializationException on participants and FK violations in UserServiceIntegrationTest caused by leftover session rows