### PR TITLE
implement SpotifyService with client credentials auth (#26 ready for …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ local.properties
 .xcode*
 
 /bin
+/.claude/

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/config/SpotifyConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/config/SpotifyConfig.java
@@ -1,0 +1,16 @@
+package ch.uzh.ifi.hase.soprafs26.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+@EnableScheduling
+public class SpotifyConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongGetDTO.java
@@ -18,11 +18,13 @@ public class SongGetDTO {
 
     private String spotifyId = null;
 
-    private String geniusId = null;
-
     private String title;
 
     private String artist;
+
+    private String albumArt = null;
+
+    private Integer durationMs;
 
     private String lyrics = null;
 
@@ -74,27 +76,6 @@ public class SongGetDTO {
         this.spotifyId = spotifyId;
     }
 
-    public SongGetDTO geniusId(String geniusId) {
-        this.geniusId = geniusId;
-        return this;
-    }
-
-    /**
-     * Get geniusId
-     *
-     * @return geniusId
-     */
-
-    @Schema(name = "geniusId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    @JsonProperty("geniusId")
-    public String getGeniusId() {
-        return geniusId;
-    }
-
-    public void setGeniusId(String geniusId) {
-        this.geniusId = geniusId;
-    }
-
     public SongGetDTO title(String title) {
         this.title = title;
         return this;
@@ -135,6 +116,36 @@ public class SongGetDTO {
 
     public void setArtist(String artist) {
         this.artist = artist;
+    }
+
+    public SongGetDTO albumArt(String albumArt) {
+        this.albumArt = albumArt;
+        return this;
+    }
+
+    @Schema(name = "albumArt", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("albumArt")
+    public String getAlbumArt() {
+        return albumArt;
+    }
+
+    public void setAlbumArt(String albumArt) {
+        this.albumArt = albumArt;
+    }
+
+    public SongGetDTO durationMs(Integer durationMs) {
+        this.durationMs = durationMs;
+        return this;
+    }
+
+    @Schema(name = "durationMs", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("durationMs")
+    public Integer getDurationMs() {
+        return durationMs;
+    }
+
+    public void setDurationMs(Integer durationMs) {
+        this.durationMs = durationMs;
     }
 
     public SongGetDTO lyrics(String lyrics) {
@@ -232,9 +243,10 @@ public class SongGetDTO {
         SongGetDTO songGetDTO = (SongGetDTO) o;
         return Objects.equals(this.id, songGetDTO.id) &&
                 Objects.equals(this.spotifyId, songGetDTO.spotifyId) &&
-                Objects.equals(this.geniusId, songGetDTO.geniusId) &&
                 Objects.equals(this.title, songGetDTO.title) &&
                 Objects.equals(this.artist, songGetDTO.artist) &&
+                Objects.equals(this.albumArt, songGetDTO.albumArt) &&
+                Objects.equals(this.durationMs, songGetDTO.durationMs) &&
                 Objects.equals(this.lyrics, songGetDTO.lyrics) &&
                 Objects.equals(this.currentVoteCount, songGetDTO.currentVoteCount) &&
                 Objects.equals(this.performed, songGetDTO.performed) &&
@@ -243,7 +255,7 @@ public class SongGetDTO {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, spotifyId, geniusId, title, artist, lyrics, currentVoteCount, performed, addedBy);
+        return Objects.hash(id, spotifyId, title, artist, albumArt, durationMs, lyrics, currentVoteCount, performed, addedBy);
     }
 
     @Override
@@ -251,9 +263,10 @@ public class SongGetDTO {
         String sb = "class SongGetDTO {\n" +
                 "    id: " + toIndentedString(id) + "\n" +
                 "    spotifyId: " + toIndentedString(spotifyId) + "\n" +
-                "    geniusId: " + toIndentedString(geniusId) + "\n" +
                 "    title: " + toIndentedString(title) + "\n" +
                 "    artist: " + toIndentedString(artist) + "\n" +
+                "    albumArt: " + toIndentedString(albumArt) + "\n" +
+                "    durationMs: " + toIndentedString(durationMs) + "\n" +
                 "    lyrics: " + toIndentedString(lyrics) + "\n" +
                 "    currentVoteCount: " + toIndentedString(currentVoteCount) + "\n" +
                 "    performed: " + toIndentedString(performed) + "\n" +

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongPostDTO.java
@@ -16,8 +16,6 @@ public class SongPostDTO {
 
     private String spotifyId = null;
 
-    private String geniusId = null;
-
     private String title;
 
     private String artist;
@@ -53,27 +51,6 @@ public class SongPostDTO {
 
     public void setSpotifyId(String spotifyId) {
         this.spotifyId = spotifyId;
-    }
-
-    public SongPostDTO geniusId(String geniusId) {
-        this.geniusId = geniusId;
-        return this;
-    }
-
-    /**
-     * Get geniusId
-     *
-     * @return geniusId
-     */
-
-    @Schema(name = "geniusId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    @JsonProperty("geniusId")
-    public String getGeniusId() {
-        return geniusId;
-    }
-
-    public void setGeniusId(String geniusId) {
-        this.geniusId = geniusId;
     }
 
     public SongPostDTO title(String title) {
@@ -128,21 +105,19 @@ public class SongPostDTO {
         }
         SongPostDTO songPostDTO = (SongPostDTO) o;
         return Objects.equals(this.spotifyId, songPostDTO.spotifyId) &&
-                Objects.equals(this.geniusId, songPostDTO.geniusId) &&
                 Objects.equals(this.title, songPostDTO.title) &&
                 Objects.equals(this.artist, songPostDTO.artist);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(spotifyId, geniusId, title, artist);
+        return Objects.hash(spotifyId, title, artist);
     }
 
     @Override
     public String toString() {
         String sb = "class SongPostDTO {\n" +
                 "    spotifyId: " + toIndentedString(spotifyId) + "\n" +
-                "    geniusId: " + toIndentedString(geniusId) + "\n" +
                 "    title: " + toIndentedString(title) + "\n" +
                 "    artist: " + toIndentedString(artist) + "\n" +
                 "}";

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongSearchResultDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongSearchResultDTO.java
@@ -15,11 +15,13 @@ public class SongSearchResultDTO {
 
     private String spotifyId = null;
 
-    private String geniusId = null;
-
     private String title;
 
     private String artist;
+
+    private String albumArt = null;
+
+    private Integer durationMs;
 
     private Boolean lyricsAvailable;
 
@@ -42,27 +44,6 @@ public class SongSearchResultDTO {
 
     public void setSpotifyId(String spotifyId) {
         this.spotifyId = spotifyId;
-    }
-
-    public SongSearchResultDTO geniusId(String geniusId) {
-        this.geniusId = geniusId;
-        return this;
-    }
-
-    /**
-     * Get geniusId
-     *
-     * @return geniusId
-     */
-
-    @Schema(name = "geniusId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    @JsonProperty("geniusId")
-    public String getGeniusId() {
-        return geniusId;
-    }
-
-    public void setGeniusId(String geniusId) {
-        this.geniusId = geniusId;
     }
 
     public SongSearchResultDTO title(String title) {
@@ -107,6 +88,36 @@ public class SongSearchResultDTO {
         this.artist = artist;
     }
 
+    public SongSearchResultDTO albumArt(String albumArt) {
+        this.albumArt = albumArt;
+        return this;
+    }
+
+    @Schema(name = "albumArt", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("albumArt")
+    public String getAlbumArt() {
+        return albumArt;
+    }
+
+    public void setAlbumArt(String albumArt) {
+        this.albumArt = albumArt;
+    }
+
+    public SongSearchResultDTO durationMs(Integer durationMs) {
+        this.durationMs = durationMs;
+        return this;
+    }
+
+    @Schema(name = "durationMs", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("durationMs")
+    public Integer getDurationMs() {
+        return durationMs;
+    }
+
+    public void setDurationMs(Integer durationMs) {
+        this.durationMs = durationMs;
+    }
+
     public SongSearchResultDTO lyricsAvailable(Boolean lyricsAvailable) {
         this.lyricsAvailable = lyricsAvailable;
         return this;
@@ -138,24 +149,26 @@ public class SongSearchResultDTO {
         }
         SongSearchResultDTO songSearchResultDTO = (SongSearchResultDTO) o;
         return Objects.equals(this.spotifyId, songSearchResultDTO.spotifyId) &&
-                Objects.equals(this.geniusId, songSearchResultDTO.geniusId) &&
                 Objects.equals(this.title, songSearchResultDTO.title) &&
                 Objects.equals(this.artist, songSearchResultDTO.artist) &&
+                Objects.equals(this.albumArt, songSearchResultDTO.albumArt) &&
+                Objects.equals(this.durationMs, songSearchResultDTO.durationMs) &&
                 Objects.equals(this.lyricsAvailable, songSearchResultDTO.lyricsAvailable);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(spotifyId, geniusId, title, artist, lyricsAvailable);
+        return Objects.hash(spotifyId, title, artist, albumArt, durationMs, lyricsAvailable);
     }
 
     @Override
     public String toString() {
         String sb = "class SongSearchResultDTO {\n" +
                 "    spotifyId: " + toIndentedString(spotifyId) + "\n" +
-                "    geniusId: " + toIndentedString(geniusId) + "\n" +
                 "    title: " + toIndentedString(title) + "\n" +
                 "    artist: " + toIndentedString(artist) + "\n" +
+                "    albumArt: " + toIndentedString(albumArt) + "\n" +
+                "    durationMs: " + toIndentedString(durationMs) + "\n" +
                 "    lyricsAvailable: " + toIndentedString(lyricsAvailable) + "\n" +
                 "}";
         return sb;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SpotifyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SpotifyService.java
@@ -1,0 +1,90 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import tools.jackson.databind.JsonNode;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class SpotifyService {
+
+    private static final Logger log = LoggerFactory.getLogger(SpotifyService.class);
+    private static final String TOKEN_URL = "https://accounts.spotify.com/api/token";
+    private static final String SEARCH_URL = "https://api.spotify.com/v1/search?q={q}&type=track&limit=5";
+
+    @Value("${spotify.client-id:}")
+    private String clientId = "";
+
+    @Value("${spotify.client-secret:}")
+    private String clientSecret = "";
+
+    private final RestTemplate restTemplate;
+    private String accessToken;
+
+    public SpotifyService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    @PostConstruct
+    public void fetchToken() {
+        if (clientId.isBlank() || clientSecret.isBlank()) {
+            log.warn("Spotify credentials not configured — skipping token fetch");
+            return;
+        }
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setBasicAuth(clientId, clientSecret);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "client_credentials");
+
+        ResponseEntity<JsonNode> response = restTemplate.postForEntity(
+                TOKEN_URL, new HttpEntity<>(body, headers), JsonNode.class);
+
+        this.accessToken = response.getBody().path("access_token").asText();
+        log.info("Spotify access token refreshed");
+    }
+
+    @Scheduled(fixedDelay = 3_500_000)
+    public void refreshToken() {
+        fetchToken();
+    }
+
+    public List<SpotifyTrack> search(String query) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        ResponseEntity<JsonNode> response = restTemplate.exchange(
+                SEARCH_URL, HttpMethod.GET, new HttpEntity<>(headers), JsonNode.class, query);
+
+        List<SpotifyTrack> tracks = new ArrayList<>();
+        for (JsonNode item : response.getBody().path("tracks").path("items")) {
+            tracks.add(new SpotifyTrack(
+                    item.path("id").asText(),
+                    item.path("name").asText(),
+                    item.path("artists").get(0).path("name").asText(),
+                    item.path("album").path("images").get(0).path("url").asText(),
+                    item.path("duration_ms").asInt()
+            ));
+        }
+        return tracks;
+    }
+
+    // Package-private accessors for testing
+    String getAccessToken() { return accessToken; }
+    void setAccessToken(String token) { this.accessToken = token; }
+    void setCredentials(String clientId, String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SpotifyTrack.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SpotifyTrack.java
@@ -1,0 +1,3 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+public record SpotifyTrack(String spotifyId, String title, String artist, String albumArt, int durationMs) {}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,3 +25,7 @@ springwolf.docket.servers.stomp.protocol=stomp
 springwolf.docket.servers.stomp.host=localhost:8080/ws
 
 springdoc.swagger-ui.url=/karaokee-openapi.json
+
+# Spotify Web API credentials (set via environment variables or local.properties)
+spotify.client-id=${SPOTIFY_CLIENT_ID:}
+spotify.client-secret=${SPOTIFY_CLIENT_SECRET:}

--- a/src/main/resources/karaokee-asyncapi.yaml
+++ b/src/main/resources/karaokee-asyncapi.yaml
@@ -242,13 +242,15 @@ components:
         spotifyId:
           type: string
           nullable: true
-        geniusId:
-          type: string
-          nullable: true
         title:
           type: string
         artist:
           type: string
+        albumArt:
+          type: string
+          nullable: true
+        durationMs:
+          type: integer
         lyrics:
           type: string
           nullable: true

--- a/src/main/resources/static/karaokee-openapi.json
+++ b/src/main/resources/static/karaokee-openapi.json
@@ -437,7 +437,7 @@
         "tags": [
           "Songs"
         ],
-        "summary": "Search songs by title or artist via Genius API (S11)",
+        "summary": "Search songs by title or artist via Spotify Web API (S11)",
         "parameters": [
           {
             "name": "query",
@@ -1003,10 +1003,6 @@
             "type": "string",
             "nullable": true
           },
-          "geniusId": {
-            "type": "string",
-            "nullable": true
-          },
           "title": {
             "type": "string",
             "example": "Dancing Queen"
@@ -1028,10 +1024,6 @@
             "type": "string",
             "nullable": true
           },
-          "geniusId": {
-            "type": "string",
-            "nullable": true
-          },
           "title": {
             "type": "string"
           },
@@ -1050,6 +1042,13 @@
           },
           "addedBy": {
             "$ref": "#/components/schemas/UserGetDTO"
+          },
+          "albumArt": {
+            "type": "string",
+            "nullable": true
+          },
+          "durationMs": {
+            "type": "integer"
           }
         }
       },
@@ -1057,10 +1056,6 @@
         "type": "object",
         "properties": {
           "spotifyId": {
-            "type": "string",
-            "nullable": true
-          },
-          "geniusId": {
             "type": "string",
             "nullable": true
           },
@@ -1072,6 +1067,13 @@
           },
           "lyricsAvailable": {
             "type": "boolean"
+          },
+          "albumArt": {
+            "type": "string",
+            "nullable": true
+          },
+          "durationMs": {
+            "type": "integer"
           }
         }
       },

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SpotifyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SpotifyServiceTest.java
@@ -1,0 +1,87 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+class SpotifyServiceTest {
+
+    private MockRestServiceServer mockServer;
+    private SpotifyService spotifyService;
+
+    @BeforeEach
+    void setup() {
+        RestTemplate restTemplate = new RestTemplate();
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+        spotifyService = new SpotifyService(restTemplate);
+        spotifyService.setAccessToken("test-token");
+    }
+
+    @Test
+    void fetchToken_storesAccessTokenFromResponse() {
+        spotifyService.setCredentials("test-client-id", "test-client-secret");
+        String tokenResponse = """
+                {"access_token":"new-token","token_type":"Bearer","expires_in":3600}
+                """;
+        mockServer.expect(requestTo("https://accounts.spotify.com/api/token"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(tokenResponse, MediaType.APPLICATION_JSON));
+
+        spotifyService.fetchToken();
+
+        assertEquals("new-token", spotifyService.getAccessToken());
+    }
+
+    @Test
+    void search_validQuery_returnsMappedTracks() {
+        String spotifyResponse = """
+                {
+                  "tracks": {
+                    "items": [{
+                      "id": "track123",
+                      "name": "Dancing Queen",
+                      "artists": [{"name": "ABBA"}],
+                      "album": {"images": [{"url": "http://img.test/art.jpg"}]},
+                      "duration_ms": 230000
+                    }]
+                  }
+                }
+                """;
+        mockServer.expect(requestTo(Matchers.containsString("/v1/search")))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer test-token"))
+                .andRespond(withSuccess(spotifyResponse, MediaType.APPLICATION_JSON));
+
+        List<SpotifyTrack> results = spotifyService.search("Dancing Queen");
+
+        assertEquals(1, results.size());
+        SpotifyTrack track = results.get(0);
+        assertEquals("track123", track.spotifyId());
+        assertEquals("Dancing Queen", track.title());
+        assertEquals("ABBA", track.artist());
+        assertEquals("http://img.test/art.jpg", track.albumArt());
+        assertEquals(230000, track.durationMs());
+    }
+
+    @Test
+    void search_emptyItemsArray_returnsEmptyList() {
+        String spotifyResponse = "{\"tracks\":{\"items\":[]}}";
+        mockServer.expect(requestTo(Matchers.containsString("/v1/search")))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(spotifyResponse, MediaType.APPLICATION_JSON));
+
+        List<SpotifyTrack> results = spotifyService.search("nonexistent song xyz");
+
+        assertTrue(results.isEmpty());
+    }
+}


### PR DESCRIPTION
…review)

  - Add SpotifyService: fetches Spotify client credentials token on startup (@PostConstruct), auto-refreshes every ~58 min (@Scheduled)
  - Add SpotifyTrack record: spotifyId, title, artist, albumArt, durationMs
  - Add SpotifyConfig: RestTemplate bean + @EnableScheduling
  - Credentials read from SPOTIFY_CLIENT_ID / SPOTIFY_CLIENT_SECRET env vars; token fetch is skipped gracefully when credentials are not configured
  - Update SongSearchResultDTO, SongGetDTO, SongPostDTO: replace geniusId with albumArt (String) and durationMs (Integer)
  - Update karaokee-openapi.json: apply same schema changes + update /songs/search summary to reference Spotify (not Genius)
  - Update karaokee-asyncapi.yaml: apply same field changes to SongDTO
  - Add spotify.client-id / spotify.client-secret to application.properties
  - Cover SpotifyService with 3 unit tests using MockRestServiceServer