### PR TITLE
#37 be implement post sessionsidvotes endpoint

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/VotingController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/VotingController.java
@@ -8,7 +8,6 @@ import ch.uzh.ifi.hase.soprafs26.service.VotingService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/VotingController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/VotingController.java
@@ -1,8 +1,14 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
+import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.VotePostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import ch.uzh.ifi.hase.soprafs26.service.VotingService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -10,8 +16,15 @@ import java.util.List;
 @RestController
 public class VotingController implements VotingApi {
 
-    // TODO: inject VotingService here
-    // VotingController(VotingService votingService) { this.votingService = votingService; }
+    private final UserService userService;
+    private final VotingService votingService;
+    private final HttpServletRequest request;
+
+    public VotingController(UserService userService, VotingService votingService, HttpServletRequest request) {
+        this.userService = userService;
+        this.votingService = votingService;
+        this.request = request;
+    }
 
     // GET /sessions/{sessionId}/votingRounds — List all voting rounds of a session
     // Voting rounds are started automatically by the server when a song ends
@@ -35,8 +48,11 @@ public class VotingController implements VotingApi {
     // Returns 201 on success
     // Returns 400 if song is not a candidate, 409 if user already voted, 410 if round is CLOSED
     @Override
-    public ResponseEntity<Void> sessionsSessionIdVotingRoundsRoundIdVotesPost(Long sessionId, Long roundId, VotePostDTO votePostDTO) {
-        // TODO: verify user hasn't voted yet, delegate to votingService.castVote(sessionId, roundId, votePostDTO)
-        throw new UnsupportedOperationException("Not implemented yet");
+    public ResponseEntity<Void> sessionsSessionIdVotingRoundsRoundIdVotesPost(
+            Long sessionId, Long roundId, VotePostDTO votePostDTO) {
+        String token = request.getHeader("token");
+        User voter = userService.getUserByToken(token);
+        votingService.castVote(sessionId, roundId, votePostDTO.getSongId(), voter);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VoteRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VoteRepository.java
@@ -1,0 +1,12 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.entity.Vote;
+import ch.uzh.ifi.hase.soprafs26.entity.VotingRound;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository("voteRepository")
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+    boolean existsByVotingRoundAndVoter(VotingRound votingRound, User voter);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
@@ -1,0 +1,8 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import ch.uzh.ifi.hase.soprafs26.entity.VotingRound;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository("votingRoundRepository")
+public interface VotingRoundRepository extends JpaRepository<VotingRound, Long> {}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
@@ -1,0 +1,62 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.VotingStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.*;
+import ch.uzh.ifi.hase.soprafs26.repository.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@Transactional
+public class VotingService {
+
+    private final VotingRoundRepository votingRoundRepository;
+    private final SongRepository songRepository;
+    private final VoteRepository voteRepository;
+
+    public VotingService(VotingRoundRepository votingRoundRepository,
+                         SongRepository songRepository, VoteRepository voteRepository) {
+        this.votingRoundRepository = votingRoundRepository;
+        this.songRepository = songRepository;
+        this.voteRepository = voteRepository;
+    }
+
+    public void castVote(Long sessionId, Long votingRoundId, Long songId, User voter) {
+        VotingRound round = votingRoundRepository.findById(votingRoundId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Voting round not found"));
+
+        // Enforce path hierarchy
+        if (!round.getSession().getId().equals(sessionId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Voting round does not belong to the specified session");
+        }
+
+        // Round still open check
+        if (round.getStatus() != VotingStatus.OPEN) {
+            throw new ResponseStatusException(HttpStatus.GONE, "Voting round is CLOSED");
+        }
+        // Voter is participant check
+        if (!round.getSession().getParticipants().contains(voter)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a participant");
+        }
+
+        // Song is candidate in voting round check
+        Song song = songRepository.findById(songId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Song not found"));
+        if (!round.getCandidates().contains(song)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Song is not a candidate");
+        }
+
+        // Voter has not yet voted check
+        if (voteRepository.existsByVotingRoundAndVoter(round, voter)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Already voted");
+        }
+
+        Vote vote = new Vote();
+        vote.setVotingRound(round);
+        vote.setVoter(voter);
+        vote.setVotedSong(song);
+        voteRepository.save(vote);
+    }
+}

--- a/src/main/resources/karaokee-asyncapi.yaml
+++ b/src/main/resources/karaokee-asyncapi.yaml
@@ -190,10 +190,6 @@ components:
 
   schemas:
 
-    UserStatus:
-      type: string
-      enum: [ONLINE, OFFLINE]
-
     SessionStatus:
       type: string
       enum: [CREATED, ACTIVE, PAUSED, ENDED]
@@ -213,8 +209,6 @@ components:
           type: integer
         username:
           type: string
-        status:
-          $ref: '#/components/schemas/UserStatus'
 
     SessionDTO:
       type: object

--- a/src/main/resources/static/karaokee-openapi.json
+++ b/src/main/resources/static/karaokee-openapi.json
@@ -756,6 +756,12 @@
           },
           "410": {
             "description": "Voting round is CLOSED"
+          },
+          "403": {
+            "description": "User is not a session participant"
+          },
+          "404": {
+            "description": "Voting round or song not found"
           }
         }
       }

--- a/src/main/resources/static/karaokee-openapi.json
+++ b/src/main/resources/static/karaokee-openapi.json
@@ -123,7 +123,7 @@
         "tags": [
           "Auth"
         ],
-        "summary": "Logout (invalidates token, sets status OFFLINE)",
+        "summary": "Logout (invalidates token)",
         "responses": {
           "204": {
             "description": "Logged out successfully"

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/VotingControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/VotingControllerTest.java
@@ -1,0 +1,196 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.VotePostDTO;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import ch.uzh.ifi.hase.soprafs26.service.VotingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(VotingController.class)
+class VotingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private VotingService votingService;
+
+    @MockitoBean
+    private UserService userService;
+
+    private User voter;
+
+    @BeforeEach
+    void setUp() {
+        voter = new User();
+        voter.setId(1L);
+        voter.setUsername("singer1");
+        voter.setToken("valid-token");
+    }
+
+
+    // POST - success
+
+    @Test
+    void castVote_validRequest_returns201() throws Exception {
+        VotePostDTO body = new VotePostDTO();
+        body.setSongId(100L);
+
+        given(userService.getUserByToken("valid-token")).willReturn(voter);
+        doNothing().when(votingService).castVote(eq(10L), eq(50L), eq(100L), eq(voter));
+
+        mockMvc.perform(post("/sessions/10/votingRounds/50/votes")
+                        .header("token", "valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(body)))
+                .andExpect(status().isCreated());
+
+        verify(votingService).castVote(eq(10L), eq(50L), eq(100L), eq(voter));
+    }
+
+
+    // POST — missing token
+
+    @Test
+    void castVote_missingToken_returns401() throws Exception {
+        VotePostDTO body = new VotePostDTO();
+        body.setSongId(100L);
+
+        given(userService.getUserByToken(any()))
+                .willThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing authentication token"));
+
+        mockMvc.perform(post("/sessions/10/votingRounds/50/votes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(body)))
+                .andExpect(status().isUnauthorized());
+
+        verify(votingService, never()).castVote(any(), any(), any(), any());
+    }
+
+
+    // POST — invalid token
+
+    @Test
+    void castVote_invalidToken_returns401() throws Exception {
+        VotePostDTO body = new VotePostDTO();
+        body.setSongId(100L);
+
+        given(userService.getUserByToken("bad-token"))
+                .willThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid or expired token"));
+
+        mockMvc.perform(post("/sessions/10/votingRounds/50/votes")
+                        .header("token", "bad-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(body)))
+                .andExpect(status().isUnauthorized());
+
+        verify(votingService, never()).castVote(any(), any(), any(), any());
+    }
+
+
+    // POST — voting round closed (410)
+
+    @Test
+    void castVote_roundClosed_returns410() throws Exception {
+        VotePostDTO body = new VotePostDTO();
+        body.setSongId(100L);
+
+        given(userService.getUserByToken("valid-token")).willReturn(voter);
+        doThrow(new ResponseStatusException(HttpStatus.GONE, "Voting round is CLOSED"))
+                .when(votingService).castVote(eq(10L), eq(50L), eq(100L), eq(voter));
+
+        mockMvc.perform(post("/sessions/10/votingRounds/50/votes")
+                        .header("token", "valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(body)))
+                .andExpect(status().isGone());
+    }
+
+
+    // POST — not a participant (403)
+
+    @Test
+    void castVote_notParticipant_returns403() throws Exception {
+        VotePostDTO body = new VotePostDTO();
+        body.setSongId(100L);
+
+        given(userService.getUserByToken("valid-token")).willReturn(voter);
+        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a participant"))
+                .when(votingService).castVote(eq(10L), eq(50L), eq(100L), eq(voter));
+
+        mockMvc.perform(post("/sessions/10/votingRounds/50/votes")
+                        .header("token", "valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(body)))
+                .andExpect(status().isForbidden());
+    }
+
+
+    // POST — song not a candidate (400)
+
+    @Test
+    void castVote_songNotCandidate_returns400() throws Exception {
+        VotePostDTO body = new VotePostDTO();
+        body.setSongId(100L);
+
+        given(userService.getUserByToken("valid-token")).willReturn(voter);
+        doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Song is not a candidate"))
+                .when(votingService).castVote(eq(10L), eq(50L), eq(100L), eq(voter));
+
+        mockMvc.perform(post("/sessions/10/votingRounds/50/votes")
+                        .header("token", "valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(body)))
+                .andExpect(status().isBadRequest());
+    }
+
+
+    // POST — already voted (409)
+
+    @Test
+    void castVote_alreadyVoted_returns409() throws Exception {
+        VotePostDTO body = new VotePostDTO();
+        body.setSongId(100L);
+
+        given(userService.getUserByToken("valid-token")).willReturn(voter);
+        doThrow(new ResponseStatusException(HttpStatus.CONFLICT, "Already voted"))
+                .when(votingService).castVote(eq(10L), eq(50L), eq(100L), eq(voter));
+
+        mockMvc.perform(post("/sessions/10/votingRounds/50/votes")
+                        .header("token", "valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(body)))
+                .andExpect(status().isConflict());
+    }
+
+
+    private String asJsonString(final Object object) {
+        try {
+            return new ObjectMapper().writeValueAsString(object);
+        }
+        catch (JacksonException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format("The request body could not be created.%s", e));
+        }
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -1,0 +1,221 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.VotingStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.*;
+import ch.uzh.ifi.hase.soprafs26.repository.SongRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.VotingRoundRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VotingServiceTest {
+
+    @Mock
+    private VotingRoundRepository votingRoundRepository;
+
+    @Mock
+    private SongRepository songRepository;
+
+    @Mock
+    private VoteRepository voteRepository;
+
+    @InjectMocks
+    private VotingService votingService;
+
+    private Session session;
+    private User voter;
+    private User nonParticipant;
+    private Song candidateSong;
+    private Song nonCandidateSong;
+    private VotingRound votingRound;
+
+    @BeforeEach
+    void setUp() {
+        voter = new User();
+        voter.setId(1L);
+        voter.setUsername("singer1");
+        voter.setToken("voter-token");
+
+        nonParticipant = new User();
+        nonParticipant.setId(2L);
+        nonParticipant.setUsername("outsider");
+        nonParticipant.setToken("outsider-token");
+
+        session = new Session();
+        session.setId(10L);
+        session.setName("Karaoke Night");
+        session.setGamePin("123456");
+        session.addParticipant(voter);
+
+        candidateSong = new Song();
+        candidateSong.setId(100L);
+        candidateSong.setTitle("Bohemian Rhapsody");
+        candidateSong.setArtist("Queen");
+        candidateSong.setSpotifyId("spotify:123");
+        candidateSong.setDurationMs(354000);
+
+        nonCandidateSong = new Song();
+        nonCandidateSong.setId(200L);
+        nonCandidateSong.setTitle("Yesterday");
+        nonCandidateSong.setArtist("The Beatles");
+        nonCandidateSong.setSpotifyId("spotify:456");
+        nonCandidateSong.setDurationMs(125000);
+
+        votingRound = new VotingRound();
+        votingRound.setId(50L);
+        votingRound.setSession(session);
+        votingRound.setStatus(VotingStatus.OPEN);
+        votingRound.setStartsAt(LocalDateTime.now());
+        votingRound.setEndsAt(LocalDateTime.now().plusSeconds(30));
+        votingRound.getCandidates().add(candidateSong);
+    }
+
+
+    // Check valid vote
+
+    @Test
+    void castVote_validInput_savesVote() {
+        when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
+        when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
+        when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
+        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+
+        assertDoesNotThrow(() -> votingService.castVote(10L, 50L, 100L, voter));
+
+        verify(voteRepository, times(1)).save(any(Vote.class));
+    }
+
+    // Check fields correctly set in vote
+
+    @Test
+    void castVote_validInput_setsCorrectFieldsOnVote() {
+        when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
+        when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
+        when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
+        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+
+        votingService.castVote(10L, 50L, 100L, voter);
+
+        verify(voteRepository).save(argThat(vote ->
+                vote.getVotingRound().equals(votingRound) &&
+                        vote.getVoter().equals(voter) &&
+                        vote.getVotedSong().equals(candidateSong)
+        ));
+    }
+
+
+    // Check invalid voting round
+
+    @Test
+    void castVote_roundNotFound_throwsNotFound() {
+        when(votingRoundRepository.findById(99L)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> votingService.castVote(10L, 99L, 100L, voter));
+
+        assertEquals(404, ex.getStatusCode().value());
+        verify(voteRepository, never()).save(any());
+    }
+
+
+    // Check round - session mismatch
+
+    @Test
+    void castVote_roundBelongsToDifferentSession_throwsBadRequest() {
+        when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> votingService.castVote(999L, 50L, 100L, voter));
+
+        assertEquals(400, ex.getStatusCode().value());
+        verify(voteRepository, never()).save(any());
+    }
+
+
+    // Check round is closed
+
+    @Test
+    void castVote_roundClosed_throwsGone() {
+        votingRound.setStatus(VotingStatus.CLOSED);
+        when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> votingService.castVote(10L, 50L, 100L, voter));
+
+        assertEquals(410, ex.getStatusCode().value());
+        verify(voteRepository, never()).save(any());
+    }
+
+
+    // Check voter is not participant
+
+    @Test
+    void castVote_notAParticipant_throwsForbidden() {
+        when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> votingService.castVote(10L, 50L, 100L, nonParticipant));
+
+        assertEquals(403, ex.getStatusCode().value());
+        verify(voteRepository, never()).save(any());
+    }
+
+
+    // Check song not found
+
+    @Test
+    void castVote_songNotFound_throwsNotFound() {
+        when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
+        when(songRepository.findById(999L)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> votingService.castVote(10L, 50L, 999L, voter));
+
+        assertEquals(404, ex.getStatusCode().value());
+        verify(voteRepository, never()).save(any());
+    }
+
+
+    // Check song is not candidate
+
+    @Test
+    void castVote_songNotACandidate_throwsBadRequest() {
+        when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
+        when(songRepository.findById(200L)).thenReturn(Optional.of(nonCandidateSong));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> votingService.castVote(10L, 50L, 200L, voter));
+
+        assertEquals(400, ex.getStatusCode().value());
+        verify(voteRepository, never()).save(any());
+    }
+
+
+    // Check user has already voted
+
+    @Test
+    void castVote_alreadyVoted_throwsConflict() {
+        when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
+        when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
+        when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(true);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> votingService.castVote(10L, 50L, 100L, voter));
+
+        assertEquals(409, ex.getStatusCode().value());
+        verify(voteRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
#37 Implement POST /sessions/{id}/votes endpoint

- Implemented the endpoint. 
- Added tests for service and controller.
- Added new error codes (see swagger):

        "responses": {
          "201": {
            "description": "Vote cast"
          },
          "400": {
            "description": "Song is not a candidate in this round"
          },
          "409": {
            "description": "User has already voted in this round"
          },
          "410": {
            "description": "Voting round is CLOSED"
          },
          "403": {
            "description": "User is not a session participant"
          },
          "404": {
            "description": "Voting round or song not found"
          } ¨

Especially for the front end crew: @Oskar-567, @Spring897 
