### PR TITLE
Implement POST /sessions/{sessionId}/songs endpoint and update relate…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ local.properties
 
 /bin
 /.claude/
+/docs/

--- a/http/critical-userstories.http
+++ b/http/critical-userstories.http
@@ -1,0 +1,233 @@
+###
+# Critical user-story endpoint catalog
+# Quick-access reference organized by user story (S1–S15).
+#
+# ✅ = fully implemented   ⏳ = controller stub exists, service pending   ❌ = not started
+#
+# Variables are captured automatically when you run session-song-flow.http in order.
+# You can also set them manually in IntelliJ environment variables.
+
+# ──────────────────────────────────────────────────────────────
+# S1 – User Management (Register, Login, Logout)
+# ──────────────────────────────────────────────────────────────
+
+### ✅ S1 Register
+POST {{baseUrl}}/users
+Content-Type: application/json
+
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+
+### ✅ S1 Login
+POST {{baseUrl}}/auth/login
+Content-Type: application/json
+
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+
+### ✅ S1 Logout
+POST {{baseUrl}}/auth/logout
+token: {{hostToken}}
+
+# ──────────────────────────────────────────────────────────────
+# S2 – Change Password
+# ──────────────────────────────────────────────────────────────
+
+### ✅ S2 Change password
+PUT {{baseUrl}}/users/{{hostUserId}}
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "oldPassword": "{{password}}",
+  "newPassword": "{{newPassword}}"
+}
+
+# ──────────────────────────────────────────────────────────────
+# S3 – Create Session
+# ──────────────────────────────────────────────────────────────
+
+### ✅ S3 Create session
+POST {{baseUrl}}/sessions
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "name": "{{sessionName}}",
+  "description": "{{sessionDescription}}"
+}
+
+### ✅ S3 Get session by ID
+GET {{baseUrl}}/sessions/{{sessionId}}
+token: {{hostToken}}
+
+### ✅ S3 Get session by game pin
+GET {{baseUrl}}/sessions/pin/{{gamePin}}
+token: {{hostToken}}
+
+# ──────────────────────────────────────────────────────────────
+# S4 – Start, Pause, Resume, End Session
+# ──────────────────────────────────────────────────────────────
+
+### ✅ S4 Start session
+PUT {{baseUrl}}/sessions/{{sessionId}}
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "status": "ACTIVE"
+}
+
+### ✅ S4 Pause session
+PUT {{baseUrl}}/sessions/{{sessionId}}
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "status": "PAUSED"
+}
+
+### ✅ S4 Resume session
+PUT {{baseUrl}}/sessions/{{sessionId}}
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "status": "ACTIVE"
+}
+
+### ✅ S4 End session
+PUT {{baseUrl}}/sessions/{{sessionId}}
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "status": "ENDED"
+}
+
+# ──────────────────────────────────────────────────────────────
+# S5 – Join, List Participants, Leave Session
+# ──────────────────────────────────────────────────────────────
+
+### ✅ S5 Join session (guest uses game pin)
+POST {{baseUrl}}/sessions/{{sessionId}}/participants
+Content-Type: application/json
+token: {{guestToken}}
+
+{
+  "gamePin": "{{gamePin}}"
+}
+
+### ✅ S5 List participants
+GET {{baseUrl}}/sessions/{{sessionId}}/participants
+token: {{hostToken}}
+
+### ✅ S5 Leave session
+DELETE {{baseUrl}}/sessions/{{sessionId}}/participants/{{guestUserId}}
+token: {{guestToken}}
+
+# ──────────────────────────────────────────────────────────────
+# S6/S10 – Search and Add Songs to Queue
+# ──────────────────────────────────────────────────────────────
+
+### ✅ S11 Search songs
+GET {{baseUrl}}/songs/search?query={{searchQuery1}}
+token: {{hostToken}}
+
+### ✅ S6/S10 Add song to queue
+POST {{baseUrl}}/sessions/{{sessionId}}/songs
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "spotifyId": "{{song1SpotifyId}}",
+  "title": "{{song1Title}}",
+  "artist": "{{song1Artist}}",
+  "albumArt": "{{song1AlbumArt}}",
+  "durationMs": {{song1DurationMs}}
+}
+
+### ⏳ S6/S10 Get session queue [Issue #50 — implementation pending]
+GET {{baseUrl}}/sessions/{{sessionId}}/songs
+token: {{hostToken}}
+
+# ──────────────────────────────────────────────────────────────
+# S7 – Skip / Remove Songs (host admin only)
+# ──────────────────────────────────────────────────────────────
+
+### ⏳ S7 Skip current song [stub only — no open issue yet]
+POST {{baseUrl}}/sessions/{{sessionId}}/songs/skip
+token: {{hostToken}}
+
+### ⏳ S7 Remove song from queue [Issue #33 — implementation pending]
+DELETE {{baseUrl}}/sessions/{{sessionId}}/songs/{{song1Id}}
+token: {{hostToken}}
+
+# ──────────────────────────────────────────────────────────────
+# S8 – Current Song
+# ──────────────────────────────────────────────────────────────
+
+### ⏳ S8 Get currently playing song [stub only — no open issue yet]
+GET {{baseUrl}}/sessions/{{sessionId}}/songs/current
+token: {{hostToken}}
+
+# ──────────────────────────────────────────────────────────────
+# S9 – Audience Reactions (WebSocket / STOMP — not a REST endpoint)
+# ──────────────────────────────────────────────────────────────
+
+### ❌ S9 Send reaction [Issue #35 — WebSocket via STOMP, no REST mapping]
+# Connect to ws://{{baseUrl}}/ws and publish to /app/sessions/{sessionId}/reactions
+POST {{baseUrl}}/sessions/{{sessionId}}/reactions
+Content-Type: application/json
+token: {{guestToken}}
+
+{
+  "type": "CLAP"
+}
+
+# ──────────────────────────────────────────────────────────────
+# S12 – Vote on Next Song
+# ──────────────────────────────────────────────────────────────
+
+### ⏳ S12 List voting rounds [stub only]
+GET {{baseUrl}}/sessions/{{sessionId}}/votingRounds
+token: {{hostToken}}
+
+### ✅ S12 Cast vote in a voting round
+# roundId is set in env file (default: 1). Adjust after listing rounds above.
+POST {{baseUrl}}/sessions/{{sessionId}}/votingRounds/{{roundId}}/votes
+Content-Type: application/json
+token: {{guestToken}}
+
+{
+  "songId": {{song2Id}}
+}
+
+# ──────────────────────────────────────────────────────────────
+# S13 – Session History
+# ──────────────────────────────────────────────────────────────
+
+### ✅ S13 User session history
+GET {{baseUrl}}/users/{{hostUserId}}/sessions
+token: {{hostToken}}
+
+# ──────────────────────────────────────────────────────────────
+# S14 – Voting Leaderboard
+# ──────────────────────────────────────────────────────────────
+
+### ✅ S14 Get voting round details / leaderboard
+# Returns vote counts per song candidate for a given round.
+GET {{baseUrl}}/sessions/{{sessionId}}/votingRounds/{{roundId}}
+token: {{hostToken}}
+
+# ──────────────────────────────────────────────────────────────
+# S15 – Session Review
+# ──────────────────────────────────────────────────────────────
+
+### ⏳ S15 Session review (available after session is ENDED) [Issue #52 — pending]
+GET {{baseUrl}}/sessions/{{sessionId}}/review
+token: {{hostToken}}

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,0 +1,45 @@
+{
+  "local": {
+    "baseUrl": "http://localhost:8080",
+    "username": "intellij_flow_user",
+    "password": "Passw0rd!",
+    "guestUsername": "intellij_flow_guest",
+    "guestPassword": "Passw0rd!",
+    "newPassword": "Passw0rd!New",
+    "hostToken": "",
+    "guestToken": "",
+    "hostUserId": 0,
+    "guestUserId": 0,
+    "sessionId": 0,
+    "gamePin": "",
+    "song1Id": 0,
+    "song2Id": 0,
+    "roundId": 1,
+    "sessionName": "IntelliJ HTTP Flow Session",
+    "sessionDescription": "Manual backend smoke test via IntelliJ HTTP client",
+    "searchQuery1": "abba",
+    "searchQuery2": "queen"
+  },
+  "prod": {
+    "baseUrl": "https://sopra-fs26-group-22-server.oa.r.appspot.com",
+    "username": "intellij_flow_user",
+    "password": "Passw0rd!",
+    "guestUsername": "intellij_flow_guest",
+    "guestPassword": "Passw0rd!",
+    "newPassword": "Passw0rd!New",
+    "hostToken": "",
+    "guestToken": "",
+    "hostUserId": 0,
+    "guestUserId": 0,
+    "sessionId": 0,
+    "gamePin": "",
+    "song1Id": 0,
+    "song2Id": 0,
+    "roundId": 1,
+    "sessionName": "IntelliJ HTTP Flow Session",
+    "sessionDescription": "Manual backend smoke test via IntelliJ HTTP client",
+    "searchQuery1": "abba",
+    "searchQuery2": "queen"
+  }
+}
+

--- a/http/session-song-flow.http
+++ b/http/session-song-flow.http
@@ -1,0 +1,490 @@
+###
+# Backend E2E smoke flow for IntelliJ HTTP Client
+# Env file: http/http-client.env.json  →  choose `local` or `prod` in IntelliJ
+#
+# Run steps IN ORDER (1 → 27). Each step captures variables that later steps need.
+# Steps marked ⏳ hit a controller stub whose service is not yet implemented → expect 501.
+# Steps marked ✅ are fully implemented → expect 2xx.
+#
+# If register returns 409, the user already exists — the Login step will re-capture the token.
+
+# ──────────────────────────────────────────────────────────────
+# PHASE 1 – Authentication (S1)
+# ──────────────────────────────────────────────────────────────
+
+### 1) ✅ Register HOST user (S1)
+# Returns 201 on first run, 409 if user already exists — both are fine.
+POST {{baseUrl}}/users
+Content-Type: application/json
+
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+
+> {%
+  client.test("register HOST: 201 created or 409 already exists", function() {
+    client.assert(response.status === 201 || response.status === 409,
+      "Expected 201 or 409, got " + response.status);
+  });
+
+  if (response.status === 201) {
+    client.global.set("hostToken", response.body.token);
+    client.global.set("hostUserId", response.body.id);
+  }
+%}
+
+### 2) ✅ Login HOST user (S1)
+# Always re-login so hostToken is fresh for all subsequent steps.
+POST {{baseUrl}}/auth/login
+Content-Type: application/json
+
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+
+> {%
+  client.test("login HOST: 200 OK", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    client.assert(response.body.token, "Expected token in response body");
+  });
+
+  client.global.set("hostToken", response.body.token);
+  client.global.set("hostUserId", response.body.id);
+%}
+
+### 3) ✅ Register GUEST user (S1)
+POST {{baseUrl}}/users
+Content-Type: application/json
+
+{
+  "username": "{{guestUsername}}",
+  "password": "{{guestPassword}}"
+}
+
+> {%
+  client.test("register GUEST: 201 created or 409 already exists", function() {
+    client.assert(response.status === 201 || response.status === 409,
+      "Expected 201 or 409, got " + response.status);
+  });
+
+  if (response.status === 201) {
+    client.global.set("guestToken", response.body.token);
+    client.global.set("guestUserId", response.body.id);
+  }
+%}
+
+### 4) ✅ Login GUEST user (S1)
+POST {{baseUrl}}/auth/login
+Content-Type: application/json
+
+{
+  "username": "{{guestUsername}}",
+  "password": "{{guestPassword}}"
+}
+
+> {%
+  client.test("login GUEST: 200 OK", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    client.assert(response.body.token, "Expected token in response body");
+  });
+
+  client.global.set("guestToken", response.body.token);
+  client.global.set("guestUserId", response.body.id);
+%}
+
+# ──────────────────────────────────────────────────────────────
+# PHASE 2 – Session Lifecycle (S3, S4)
+# ──────────────────────────────────────────────────────────────
+
+### 5) ✅ Create session as HOST (S3)
+POST {{baseUrl}}/sessions
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "name": "{{sessionName}}",
+  "description": "{{sessionDescription}}"
+}
+
+> {%
+  client.test("create session: 201 Created", function() {
+    client.assert(response.status === 201, "Expected 201, got " + response.status);
+    client.assert(response.body.id, "Expected session id in response");
+    client.assert(response.body.gamePin, "Expected gamePin in response");
+  });
+
+  client.global.set("sessionId", response.body.id);
+  client.global.set("gamePin", response.body.gamePin);
+%}
+
+### 6) ✅ Get session by ID (S3)
+GET {{baseUrl}}/sessions/{{sessionId}}
+token: {{hostToken}}
+
+> {%
+  client.test("get session by ID: 200 OK", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    client.assert(response.body.id == client.global.get("sessionId"), "Session ID mismatch");
+  });
+%}
+
+### 7) ✅ Start session — ACTIVE (S4)
+PUT {{baseUrl}}/sessions/{{sessionId}}
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "status": "ACTIVE"
+}
+
+> {%
+  client.test("start session: 200 OK", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+### 8) ✅ Pause session — PAUSED (S4)
+PUT {{baseUrl}}/sessions/{{sessionId}}
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "status": "PAUSED"
+}
+
+> {%
+  client.test("pause session: 200 OK", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+### 9) ✅ Resume session — ACTIVE again (S4)
+PUT {{baseUrl}}/sessions/{{sessionId}}
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "status": "ACTIVE"
+}
+
+> {%
+  client.test("resume session: 200 OK", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+# ──────────────────────────────────────────────────────────────
+# PHASE 3 – Participants (S5)
+# ──────────────────────────────────────────────────────────────
+
+### 10) ✅ GUEST joins session via game pin (S5)
+POST {{baseUrl}}/sessions/{{sessionId}}/participants
+Content-Type: application/json
+token: {{guestToken}}
+
+{
+  "gamePin": "{{gamePin}}"
+}
+
+> {%
+  client.test("guest joins session: 200 OK", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+### 11) ✅ List session participants (S5)
+GET {{baseUrl}}/sessions/{{sessionId}}/participants
+token: {{hostToken}}
+
+> {%
+  client.test("list participants: 200 OK with at least HOST and GUEST", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    client.assert(Array.isArray(response.body), "Expected array of participants");
+    client.assert(response.body.length >= 2, "Expected at least 2 participants (host + guest)");
+  });
+%}
+
+### 12) ✅ Get session by game pin (S5)
+GET {{baseUrl}}/sessions/pin/{{gamePin}}
+token: {{guestToken}}
+
+> {%
+  client.test("get session by game pin: 200 OK", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    client.assert(response.body.gamePin == client.global.get("gamePin"), "gamePin mismatch");
+  });
+%}
+
+# ──────────────────────────────────────────────────────────────
+# PHASE 4 – Songs / Queue (S6, S10, S11)
+# ──────────────────────────────────────────────────────────────
+
+### 13) ✅ HOST searches for songs — query 1 (S11)
+GET {{baseUrl}}/songs/search?query={{searchQuery1}}
+token: {{hostToken}}
+
+> {%
+  client.test("song search query 1: 200 OK with results", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    client.assert(Array.isArray(response.body), "Expected array of songs");
+    client.assert(response.body.length > 0, "Expected at least one search result");
+  });
+
+  // Prefer a song with lyrics available so the karaoke feature works
+  const picked = response.body.find(song => song.lyricsAvailable) || response.body[0];
+  client.global.set("song1SpotifyId", picked.spotifyId);
+  client.global.set("song1Title", picked.title);
+  client.global.set("song1Artist", picked.artist);
+  client.global.set("song1AlbumArt", picked.albumArt || "");
+  client.global.set("song1DurationMs", String(picked.durationMs));
+%}
+
+### 14) ✅ HOST adds song 1 to the queue (S6/S10)
+POST {{baseUrl}}/sessions/{{sessionId}}/songs
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "spotifyId": "{{song1SpotifyId}}",
+  "title": "{{song1Title}}",
+  "artist": "{{song1Artist}}",
+  "albumArt": "{{song1AlbumArt}}",
+  "durationMs": {{song1DurationMs}}
+}
+
+> {%
+  client.test("add song 1 (HOST): 201 Created", function() {
+    client.assert(response.status === 201, "Expected 201, got " + response.status);
+    client.assert(response.body.id, "Expected song id in response");
+  });
+
+  client.global.set("song1Id", response.body.id);
+%}
+
+### 15) ✅ GUEST searches for songs — query 2 (S11)
+GET {{baseUrl}}/songs/search?query={{searchQuery2}}
+token: {{guestToken}}
+
+> {%
+  client.test("song search query 2: 200 OK with results", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    client.assert(Array.isArray(response.body), "Expected array of songs");
+    client.assert(response.body.length > 0, "Expected at least one search result");
+  });
+
+  const picked = response.body.find(song => song.lyricsAvailable) || response.body[0];
+  client.global.set("song2SpotifyId", picked.spotifyId);
+  client.global.set("song2Title", picked.title);
+  client.global.set("song2Artist", picked.artist);
+  client.global.set("song2AlbumArt", picked.albumArt || "");
+  client.global.set("song2DurationMs", String(picked.durationMs));
+%}
+
+### 16) ✅ GUEST adds song 2 to the queue (S6/S10)
+POST {{baseUrl}}/sessions/{{sessionId}}/songs
+Content-Type: application/json
+token: {{guestToken}}
+
+{
+  "spotifyId": "{{song2SpotifyId}}",
+  "title": "{{song2Title}}",
+  "artist": "{{song2Artist}}",
+  "albumArt": "{{song2AlbumArt}}",
+  "durationMs": {{song2DurationMs}}
+}
+
+> {%
+  client.test("add song 2 (GUEST): 201 Created", function() {
+    client.assert(response.status === 201, "Expected 201, got " + response.status);
+    client.assert(response.body.id, "Expected song id in response");
+  });
+
+  client.global.set("song2Id", response.body.id);
+%}
+
+### 17) ⏳ Get session queue — both songs should appear (S6/S10) [Issue #50]
+# Controller stub exists. Returns 501 until Issue #50 is implemented.
+GET {{baseUrl}}/sessions/{{sessionId}}/songs
+token: {{hostToken}}
+
+> {%
+  client.test("get queue: 200 OK or 501 pending (Issue #50)", function() {
+    client.assert(response.status === 200 || response.status === 501,
+      "Expected 200 or 501, got " + response.status);
+  });
+
+  if (response.status === 200) {
+    client.assert(Array.isArray(response.body), "Expected array of queued songs");
+    client.assert(response.body.length >= 2, "Expected at least 2 songs in queue");
+  }
+%}
+
+# ──────────────────────────────────────────────────────────────
+# PHASE 5 – Voting (S12, S14)
+# ──────────────────────────────────────────────────────────────
+
+### 18) ⏳ List all voting rounds for the session (S12/S14)
+# Controller stub exists. Returns 501 if not yet implemented.
+GET {{baseUrl}}/sessions/{{sessionId}}/votingRounds
+token: {{hostToken}}
+
+> {%
+  client.test("list voting rounds: 200 OK or 501 pending", function() {
+    client.assert(response.status === 200 || response.status === 501,
+      "Expected 200 or 501, got " + response.status);
+  });
+%}
+
+### 19) ✅ GUEST casts a vote in voting round (S12)
+# roundId defaults to 1 (see env file). Adjust if your round ID differs.
+POST {{baseUrl}}/sessions/{{sessionId}}/votingRounds/{{roundId}}/votes
+Content-Type: application/json
+token: {{guestToken}}
+
+{
+  "songId": {{song2Id}}
+}
+
+> {%
+  client.test("cast vote: 200 or 201", function() {
+    client.assert(response.status === 200 || response.status === 201,
+      "Expected 200 or 201, got " + response.status);
+  });
+%}
+
+### 20) ✅ Get voting round details / leaderboard (S14)
+GET {{baseUrl}}/sessions/{{sessionId}}/votingRounds/{{roundId}}
+token: {{hostToken}}
+
+> {%
+  client.test("get voting round: 200 OK", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+# ──────────────────────────────────────────────────────────────
+# PHASE 6 – Teardown & History (S2, S4, S5, S13, S15)
+# ──────────────────────────────────────────────────────────────
+
+### 21) ✅ Session history for HOST (S13)
+GET {{baseUrl}}/users/{{hostUserId}}/sessions
+token: {{hostToken}}
+
+> {%
+  client.test("session history: 200 OK", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    client.assert(Array.isArray(response.body), "Expected array of sessions");
+  });
+%}
+
+### 22) ✅ GUEST leaves the session (S5)
+DELETE {{baseUrl}}/sessions/{{sessionId}}/participants/{{guestUserId}}
+token: {{guestToken}}
+
+> {%
+  client.test("guest leaves session: 200 or 204", function() {
+    client.assert(response.status === 200 || response.status === 204,
+      "Expected 200 or 204, got " + response.status);
+  });
+%}
+
+### 23) ✅ HOST ends the session (S4)
+PUT {{baseUrl}}/sessions/{{sessionId}}
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "status": "ENDED"
+}
+
+> {%
+  client.test("end session: 200 OK", function() {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+### 24) ⏳ Session review after session ended (S15) [Issue #52]
+# Controller stub exists. Returns 501 until Issue #52 is implemented.
+GET {{baseUrl}}/sessions/{{sessionId}}/review
+token: {{hostToken}}
+
+> {%
+  client.test("session review: 200 OK or 501 pending (Issue #52)", function() {
+    client.assert(response.status === 200 || response.status === 501,
+      "Expected 200 or 501, got " + response.status);
+  });
+%}
+
+### 25) ✅ Change HOST password (S2)
+# WARNING: After this succeeds the login password becomes {{newPassword}}.
+# Re-run step 2 with newPassword to refresh the token if needed.
+PUT {{baseUrl}}/users/{{hostUserId}}
+Content-Type: application/json
+token: {{hostToken}}
+
+{
+  "oldPassword": "{{password}}",
+  "newPassword": "{{newPassword}}"
+}
+
+> {%
+  client.test("change password: 200 or 204", function() {
+    client.assert(response.status === 200 || response.status === 204,
+      "Expected 200 or 204, got " + response.status);
+  });
+%}
+
+### 26) ✅ Logout HOST (S1)
+POST {{baseUrl}}/auth/logout
+token: {{hostToken}}
+
+> {%
+  client.test("logout HOST: 200 or 204", function() {
+    client.assert(response.status === 200 || response.status === 204,
+      "Expected 200 or 204, got " + response.status);
+  });
+%}
+
+### 27) ✅ Logout GUEST (S1)
+POST {{baseUrl}}/auth/logout
+token: {{guestToken}}
+
+> {%
+  client.test("logout GUEST: 200 or 204", function() {
+    client.assert(response.status === 200 || response.status === 204,
+      "Expected 200 or 204, got " + response.status);
+  });
+%}
+
+# ──────────────────────────────────────────────────────────────
+# APPENDIX – Pending endpoints (not yet in main flow)
+# Controller stubs exist for all of these — service implementations are open issues.
+# ──────────────────────────────────────────────────────────────
+
+### A1) ⏳ Current song being performed (S8) — stub only, no open issue
+GET {{baseUrl}}/sessions/{{sessionId}}/songs/current
+token: {{hostToken}}
+
+### A2) ⏳ Skip current song (S7) — stub only, no open issue
+POST {{baseUrl}}/sessions/{{sessionId}}/songs/skip
+token: {{hostToken}}
+
+### A3) ⏳ Remove a song from the queue (S7) [Issue #33]
+DELETE {{baseUrl}}/sessions/{{sessionId}}/songs/{{song1Id}}
+token: {{hostToken}}
+
+### A4) ⏳ Mark song as played [Issue #42]
+PUT {{baseUrl}}/sessions/{{sessionId}}/songs/{{song2Id}}/played
+token: {{hostToken}}
+
+### A5) ⏳ Send audience reaction (S9) [Issue #9 — WebSocket via STOMP, not REST]
+# This endpoint may not have a REST mapping; reactions go via /ws topic.
+POST {{baseUrl}}/sessions/{{sessionId}}/reactions
+Content-Type: application/json
+token: {{guestToken}}
+
+{
+  "type": "CLAP"
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/config/SpotifyConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/config/SpotifyConfig.java
@@ -1,6 +1,5 @@
 package ch.uzh.ifi.hase.soprafs26.config;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/config/SpotifyConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/config/SpotifyConfig.java
@@ -3,6 +3,7 @@ package ch.uzh.ifi.hase.soprafs26.config;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestTemplate;
@@ -11,13 +12,13 @@ import org.springframework.web.client.RestTemplate;
 @EnableScheduling
 public class SpotifyConfig {
 
+    @Primary
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
     }
 
     @Bean
-    @Qualifier("lyricsRestTemplate")
     public RestTemplate lyricsRestTemplate() {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(500);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/config/SpotifyConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/config/SpotifyConfig.java
@@ -1,7 +1,9 @@
 package ch.uzh.ifi.hase.soprafs26.config;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestTemplate;
 
@@ -12,5 +14,14 @@ public class SpotifyConfig {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+
+    @Bean
+    @Qualifier("lyricsRestTemplate")
+    public RestTemplate lyricsRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(500);
+        factory.setReadTimeout(1_000);
+        return new RestTemplate(factory);
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/config/WebSocketConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package ch.uzh.ifi.hase.soprafs26.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/AuthController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/AuthController.java
@@ -47,10 +47,7 @@ public class AuthController implements AuthApi {
     // Returns 204 on success, 401 if unauthorized
     @Override
     public ResponseEntity<Void> authLogoutPost() {
-        String token = request.getHeader("Authorization");
-        if (token != null && token.startsWith("Bearer ")) {
-            token = token.substring(7);
-        }
+        String token = request.getHeader("token");
         userService.logoutUser(token);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
@@ -39,11 +39,11 @@ public class SongsController implements SongsApi {
     }
 
     // POST /sessions/{sessionId}/songs — Add a song to the queue (S6, S10)
-    // Returns 201 + SongGetDTO, 404 if session not found, 422 if lyrics unavailable
+    // Returns 201 + SongGetDTO, 404 if session not found
     @Override
     public ResponseEntity<SongGetDTO> sessionsSessionIdSongsPost(Long sessionId, SongPostDTO songPostDTO) {
-        // TODO: delegate to songService.addToQueue(sessionId, songPostDTO)
-        throw new UnsupportedOperationException("Not implemented yet");
+        SongGetDTO result = songService.addToQueue(sessionId, songPostDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 
     // GET /sessions/{sessionId}/songs/current — Get the currently playing song with lyrics (S8)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongPostDTO.java
@@ -20,6 +20,10 @@ public class SongPostDTO {
 
     private String artist;
 
+    private String albumArt = null;
+
+    private Integer durationMs;
+
     public SongPostDTO() {
         super();
     }
@@ -93,6 +97,27 @@ public class SongPostDTO {
 
     public void setArtist(String artist) {
         this.artist = artist;
+    }
+
+    @Schema(name = "albumArt", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("albumArt")
+    public String getAlbumArt() {
+        return albumArt;
+    }
+
+    public void setAlbumArt(String albumArt) {
+        this.albumArt = albumArt;
+    }
+
+    @NotNull
+    @Schema(name = "durationMs", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("durationMs")
+    public Integer getDurationMs() {
+        return durationMs;
+    }
+
+    public void setDurationMs(Integer durationMs) {
+        this.durationMs = durationMs;
     }
 
     @Override

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongPostDTO.java
@@ -31,7 +31,8 @@ public class SongPostDTO {
     /**
      * Constructor with only required parameters
      */
-    public SongPostDTO(String title, String artist) {
+    public SongPostDTO(String spotifyId, String title, String artist) {
+        this.spotifyId = spotifyId;
         this.title = title;
         this.artist = artist;
     }
@@ -47,7 +48,8 @@ public class SongPostDTO {
      * @return spotifyId
      */
 
-    @Schema(name = "spotifyId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @NotNull
+    @Schema(name = "spotifyId", requiredMode = Schema.RequiredMode.REQUIRED)
     @JsonProperty("spotifyId")
     public String getSpotifyId() {
         return spotifyId;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongPostDTO.java
@@ -133,12 +133,14 @@ public class SongPostDTO {
         SongPostDTO songPostDTO = (SongPostDTO) o;
         return Objects.equals(this.spotifyId, songPostDTO.spotifyId) &&
                 Objects.equals(this.title, songPostDTO.title) &&
-                Objects.equals(this.artist, songPostDTO.artist);
+                Objects.equals(this.artist, songPostDTO.artist) &&
+                Objects.equals(this.albumArt, songPostDTO.albumArt) &&
+                Objects.equals(this.durationMs, songPostDTO.durationMs);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(spotifyId, title, artist);
+        return Objects.hash(spotifyId, title, artist, albumArt, durationMs);
     }
 
     @Override
@@ -147,6 +149,8 @@ public class SongPostDTO {
                 "    spotifyId: " + toIndentedString(spotifyId) + "\n" +
                 "    title: " + toIndentedString(title) + "\n" +
                 "    artist: " + toIndentedString(artist) + "\n" +
+                "    albumArt: " + toIndentedString(albumArt) + "\n" +
+                "    durationMs: " + toIndentedString(durationMs) + "\n" +
                 "}";
         return sb;
     }
@@ -162,4 +166,3 @@ public class SongPostDTO {
         return o.toString().replace("\n", "\n    ");
     }
 }
-

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LyricsService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LyricsService.java
@@ -1,8 +1,10 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 import tools.jackson.databind.JsonNode;
 
@@ -13,21 +15,21 @@ public class LyricsService {
 
     private final RestTemplate restTemplate;
 
-    public LyricsService(RestTemplate restTemplate) {
+    public LyricsService(@Qualifier("lyricsRestTemplate") RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
     }
 
     /**
      * Fetches lyrics for the given artist and title.
      *
-     * @return lyrics text, or null if not found
+     * @return lyrics text, or null if not found or if the request times out (2 s)
      */
     public String fetchLyrics(String artist, String title) {
         try {
             ResponseEntity<JsonNode> response = restTemplate.getForEntity(LYRICS_URL, JsonNode.class, artist, title);
             return response.getBody().path("lyrics").asText(null);
         }
-        catch (HttpClientErrorException.NotFound e) {
+        catch (HttpClientErrorException.NotFound | ResourceAccessException e) {
             return null;
         }
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LyricsService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LyricsService.java
@@ -22,7 +22,7 @@ public class LyricsService {
     /**
      * Fetches lyrics for the given artist and title.
      *
-     * @return lyrics text, or null if not found or if the request times out (2 s)
+     * @return lyrics text, or null if not found or if the request times out (500 ms connect / 1000 ms read)
      */
     public String fetchLyrics(String artist, String title) {
         try {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LyricsService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LyricsService.java
@@ -1,6 +1,8 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
@@ -11,6 +13,7 @@ import tools.jackson.databind.JsonNode;
 @Service
 public class LyricsService {
 
+    private static final Logger log = LoggerFactory.getLogger(LyricsService.class);
     private static final String LYRICS_URL = "https://api.lyrics.ovh/v1/{artist}/{title}";
 
     private final RestTemplate restTemplate;
@@ -22,7 +25,8 @@ public class LyricsService {
     /**
      * Fetches lyrics for the given artist and title.
      *
-     * @return lyrics text, or null if not found or if the request times out (500 ms connect / 1000 ms read)
+     * @return lyrics text, or null if not found or if the request cannot be completed due to
+     *         connection/read failures (including configured timeouts of 500 ms connect / 1000 ms read)
      */
     public String fetchLyrics(String artist, String title) {
         try {
@@ -30,6 +34,9 @@ public class LyricsService {
             return response.getBody().path("lyrics").asText(null);
         }
         catch (HttpClientErrorException.NotFound | ResourceAccessException e) {
+            if (e instanceof ResourceAccessException) {
+                log.debug("Lyrics request failed for artist='{}', title='{}'", artist, title, e);
+            }
             return null;
         }
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -5,6 +5,9 @@ import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,12 +16,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
-import java.util.List;
 
 @Service
 @Transactional
@@ -28,12 +33,15 @@ public class SessionService {
 
     private final SessionRepository sessionRepository;
     private final UserRepository userRepository;
+    private final SongWebSocketPublisher songWebSocketPublisher;
 
     @Autowired
     public SessionService(SessionRepository sessionRepository,
-                          UserRepository userRepository) {
+                          UserRepository userRepository,
+                          SongWebSocketPublisher songWebSocketPublisher) {
         this.sessionRepository = sessionRepository;
         this.userRepository = userRepository;
+        this.songWebSocketPublisher = songWebSocketPublisher;
     }
 
     /*
@@ -142,6 +150,13 @@ public class SessionService {
         }
 
         Session saved = sessionRepository.save(session);
+
+        Map<Long, Long> emptyVotes = new HashMap<>();
+        List<SongGetDTO> queue = saved.getPlaylist().stream()
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                .toList();
+        songWebSocketPublisher.broadcastQueue(sessionId, queue);
+
         log.debug("User {} joined session {}", userId, sessionId);
         return saved;
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -157,6 +157,12 @@ public class SessionService {
                 .toList();
         songWebSocketPublisher.broadcastQueue(sessionId, queue);
 
+        saved.getPlaylist().stream()
+                .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
+                .findFirst()
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                .ifPresent(s -> songWebSocketPublisher.broadcastCurrentSong(sessionId, s));
+
         log.debug("User {} joined session {}", userId, sessionId);
         return saved;
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -8,10 +8,10 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.SongPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
-import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -84,11 +84,11 @@ public class SongService {
         song.setDurationMs(dto.getDurationMs());
         song.setLyrics(getCachedLyrics(dto.getSpotifyId())); // nullable
         song.setSession(session);
-        songRepository.save(song);
+        song = songRepository.save(song);
 
         session.addSong(song); // update in-memory list for broadcast
 
-        Map<Long, Long> emptyVotes = new HashMap<>();
+        Map<Long, Long> emptyVotes = Collections.emptyMap();
 
         // Broadcast updated queue (no votes yet → empty counts map)
         List<SongGetDTO> queue = session.getPlaylist().stream()
@@ -108,6 +108,10 @@ public class SongService {
     }
 
     Map<String, Optional<String>> getLyricsCache() {
-        return lyricsCache;
+        return Map.copyOf(lyricsCache);
+    }
+
+    void cacheLyrics(String spotifyId, String lyrics) {
+        lyricsCache.put(spotifyId, Optional.ofNullable(lyrics));
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -88,13 +88,15 @@ public class SongService {
 
         session.addSong(song); // update in-memory list for broadcast
 
+        Map<Long, Long> emptyVotes = new HashMap<>();
+
         // Broadcast updated queue (no votes yet → empty counts map)
         List<SongGetDTO> queue = session.getPlaylist().stream()
-                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, new HashMap<>()))
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
                 .toList();
         songWebSocketPublisher.broadcastQueue(sessionId, queue);
 
-        return DTOMapper.INSTANCE.toSongGetDTO(song, new HashMap<>());
+        return DTOMapper.INSTANCE.toSongGetDTO(song, emptyVotes);
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -1,8 +1,17 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
+import ch.uzh.ifi.hase.soprafs26.entity.Session;
+import ch.uzh.ifi.hase.soprafs26.entity.Song;
+import ch.uzh.ifi.hase.soprafs26.repository.SongRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SongPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
+import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -15,13 +24,21 @@ public class SongService {
 
     private final SpotifyService spotifyService;
     private final LyricsService lyricsService;
+    private final SongRepository songRepository;
+    private final SessionService sessionService;
+    private final SongWebSocketPublisher songWebSocketPublisher;
 
     // ConcurrentHashMap doesn't allow null values, so we wrap in Optional
     private final Map<String, Optional<String>> lyricsCache = new ConcurrentHashMap<>();
 
-    public SongService(SpotifyService spotifyService, LyricsService lyricsService) {
+    public SongService(SpotifyService spotifyService, LyricsService lyricsService,
+                       SongRepository songRepository, SessionService sessionService,
+                       SongWebSocketPublisher songWebSocketPublisher) {
         this.spotifyService = spotifyService;
         this.lyricsService = lyricsService;
+        this.songRepository = songRepository;
+        this.sessionService = sessionService;
+        this.songWebSocketPublisher = songWebSocketPublisher;
     }
 
     /**
@@ -55,11 +72,40 @@ public class SongService {
         }).collect(Collectors.toList());
     }
 
+    @Transactional
+    public SongGetDTO addToQueue(Long sessionId, SongPostDTO dto) {
+        Session session = sessionService.getSessionById(sessionId); // throws 404
+
+        Song song = new Song();
+        song.setSpotifyId(dto.getSpotifyId());
+        song.setTitle(dto.getTitle());
+        song.setArtist(dto.getArtist());
+        song.setAlbumArt(dto.getAlbumArt());
+        song.setDurationMs(dto.getDurationMs());
+        song.setLyrics(getCachedLyrics(dto.getSpotifyId())); // nullable
+        song.setSession(session);
+        songRepository.save(song);
+
+        session.addSong(song); // update in-memory list for broadcast
+
+        // Broadcast updated queue (no votes yet → empty counts map)
+        List<SongGetDTO> queue = session.getPlaylist().stream()
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, new HashMap<>()))
+                .toList();
+        songWebSocketPublisher.broadcastQueue(sessionId, queue);
+
+        return DTOMapper.INSTANCE.toSongGetDTO(song, new HashMap<>());
+    }
+
     /**
      * Returns the cached lyrics for a given Spotify track ID, or null if not cached
      * or if lyrics were not available.
      */
     public String getCachedLyrics(String spotifyId) {
         return lyricsCache.getOrDefault(spotifyId, Optional.empty()).orElse(null);
+    }
+
+    Map<String, Optional<String>> getLyricsCache() {
+        return lyricsCache;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImpl.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImpl.java
@@ -1,0 +1,28 @@
+package ch.uzh.ifi.hase.soprafs26.websocket;
+
+
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class SongWebSocketPublisherImpl implements SongWebSocketPublisher {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public SongWebSocketPublisherImpl(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    @Override
+    public void broadcastQueue(Long sessionId, List<SongGetDTO> queue) {
+        messagingTemplate.convertAndSend("/topic/sessions/" + sessionId + "/queue", queue);
+    }
+
+    @Override
+    public void broadcastCurrentSong(Long sessionId, SongGetDTO currentSong) {
+        messagingTemplate.convertAndSend("/topic/sessions/" + sessionId + "/currentSong", currentSong);
+    }
+}
+

--- a/src/main/resources/static/karaokee-openapi.json
+++ b/src/main/resources/static/karaokee-openapi.json
@@ -17,7 +17,7 @@
   ],
   "security": [
     {
-      "BearerAuth": []
+      "token": []
     }
   ],
   "tags": [
@@ -1039,7 +1039,8 @@
         "type": "object",
         "required": [
           "title",
-          "artist"
+          "artist",
+          "durationMs"
         ],
         "properties": {
           "spotifyId": {
@@ -1053,6 +1054,14 @@
           "artist": {
             "type": "string",
             "example": "ABBA"
+          },
+          "albumArt": {
+            "type": "string",
+            "nullable": true
+          },
+          "durationMs": {
+            "type": "integer",
+            "example": 354000
           }
         }
       },
@@ -1175,10 +1184,10 @@
       }
     },
     "securitySchemes": {
-      "BearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "UUID"
+      "token": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "token"
       }
     }
   }

--- a/src/main/resources/static/karaokee-openapi.json
+++ b/src/main/resources/static/karaokee-openapi.json
@@ -1038,14 +1038,14 @@
       "SongPostDTO": {
         "type": "object",
         "required": [
+          "spotifyId",
           "title",
           "artist",
           "durationMs"
         ],
         "properties": {
           "spotifyId": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           "title": {
             "type": "string",

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SongsControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SongsControllerTest.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.service.SongService;
 import org.junit.jupiter.api.Test;
@@ -8,12 +9,17 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
 import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(SongsController.class)
@@ -61,6 +67,47 @@ class SongsControllerTest {
     @Test
     void songsSearch_missingQuery_returns400() throws Exception {
         mockMvc.perform(get("/songs/search")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void addSongToQueue_validRequest_returns201WithSong() throws Exception {
+        SongGetDTO response = new SongGetDTO();
+        response.setId(1L);
+        response.setTitle("Dancing Queen");
+        response.setArtist("ABBA");
+        response.setSpotifyId("track123");
+
+        given(songService.addToQueue(eq(42L), any())).willReturn(response);
+
+        mockMvc.perform(post("/sessions/42/songs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"spotifyId\":\"track123\",\"title\":\"Dancing Queen\",\"artist\":\"ABBA\",\"durationMs\":230000}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id", is(1)))
+                .andExpect(jsonPath("$.title", is("Dancing Queen")))
+                .andExpect(jsonPath("$.artist", is("ABBA")));
+    }
+
+    @Test
+    void addSongToQueue_sessionNotFound_returns404() throws Exception {
+        given(songService.addToQueue(eq(99L), any()))
+                .willThrow(new ResponseStatusException(NOT_FOUND, "Session not found"));
+
+        mockMvc.perform(post("/sessions/99/songs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"spotifyId\":\"track123\",\"title\":\"Dancing Queen\",\"artist\":\"ABBA\",\"durationMs\":230000}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void addSongToQueue_missingTitle_returns400() throws Exception {
+        mockMvc.perform(post("/sessions/42/songs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"spotifyId\":\"track123\",\"artist\":\"ABBA\"}")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -5,6 +5,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +29,9 @@ class SessionServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private SongWebSocketPublisher songWebSocketPublisher;
 
     @InjectMocks
     private SessionService sessionService;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -103,7 +103,7 @@ class SongServiceTest {
         dto.setDurationMs(230000);
 
         // Pre-populate lyrics cache
-        songService.getLyricsCache().put("track123", java.util.Optional.of("Here I go again..."));
+        songService.cacheLyrics("track123", "Here I go again...");
 
         when(sessionService.getSessionById(1L)).thenReturn(session);
         when(songRepository.save(any(Song.class))).thenAnswer(inv -> {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -13,7 +13,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -100,8 +99,8 @@ class SongServiceTest {
     @Test
     void addToQueue_persistsSongAndBroadcastsQueue() {
         Session session = new Session();
-        SongPostDTO dto = new SongPostDTO("Dancing Queen", "ABBA");
-        dto.setSpotifyId("track123");
+        SongPostDTO dto = new SongPostDTO("track123", "Dancing Queen", "ABBA");
+        dto.setDurationMs(230000);
 
         // Pre-populate lyrics cache
         songService.getLyricsCache().put("track123", java.util.Optional.of("Here I go again..."));
@@ -125,8 +124,8 @@ class SongServiceTest {
     @Test
     void addToQueue_noLyricsCache_persistsSongWithNullLyrics() {
         Session session = new Session();
-        SongPostDTO dto = new SongPostDTO("Unknown Song", "Unknown");
-        dto.setSpotifyId("uncached");
+        SongPostDTO dto = new SongPostDTO("uncached", "Unknown Song", "Unknown");
+        dto.setDurationMs(180000);
 
         when(sessionService.getSessionById(2L)).thenReturn(session);
         when(songRepository.save(any(Song.class))).thenAnswer(inv -> inv.getArgument(0));

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -1,15 +1,23 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
+import ch.uzh.ifi.hase.soprafs26.entity.Session;
+import ch.uzh.ifi.hase.soprafs26.entity.Song;
+import ch.uzh.ifi.hase.soprafs26.repository.SongRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SongPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
+import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 class SongServiceTest {
@@ -19,6 +27,15 @@ class SongServiceTest {
 
     @Mock
     private LyricsService lyricsService;
+
+    @Mock
+    private SongRepository songRepository;
+
+    @Mock
+    private SessionService sessionService;
+
+    @Mock
+    private SongWebSocketPublisher songWebSocketPublisher;
 
     @InjectMocks
     private SongService songService;
@@ -78,5 +95,45 @@ class SongServiceTest {
         songService.search("Unknown");
 
         assertNull(songService.getCachedLyrics("id4"));
+    }
+
+    @Test
+    void addToQueue_persistsSongAndBroadcastsQueue() {
+        Session session = new Session();
+        SongPostDTO dto = new SongPostDTO("Dancing Queen", "ABBA");
+        dto.setSpotifyId("track123");
+
+        // Pre-populate lyrics cache
+        songService.getLyricsCache().put("track123", java.util.Optional.of("Here I go again..."));
+
+        when(sessionService.getSessionById(1L)).thenReturn(session);
+        when(songRepository.save(any(Song.class))).thenAnswer(inv -> {
+            Song s = inv.getArgument(0);
+            s.setId(10L);
+            return s;
+        });
+
+        SongGetDTO result = songService.addToQueue(1L, dto);
+
+        verify(songRepository).save(any(Song.class));
+        verify(songWebSocketPublisher).broadcastQueue(eq(1L), anyList());
+        assertEquals("Dancing Queen", result.getTitle());
+        assertEquals("ABBA", result.getArtist());
+        assertEquals("Here I go again...", result.getLyrics());
+    }
+
+    @Test
+    void addToQueue_noLyricsCache_persistsSongWithNullLyrics() {
+        Session session = new Session();
+        SongPostDTO dto = new SongPostDTO("Unknown Song", "Unknown");
+        dto.setSpotifyId("uncached");
+
+        when(sessionService.getSessionById(2L)).thenReturn(session);
+        when(songRepository.save(any(Song.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        SongGetDTO result = songService.addToQueue(2L, dto);
+
+        assertNull(result.getLyrics());
+        verify(songWebSocketPublisher).broadcastQueue(eq(2L), anyList());
     }
 }


### PR DESCRIPTION
This pull request introduces several major improvements and new features, primarily focused on enhancing song queue management, real-time updates via WebSockets, and DTO validation. It also adds a comprehensive HTTP client catalog for manual testing, environment configuration for local and production, and improves backend service integration and error handling. Below are the most important changes grouped by theme.

**Song Queue & WebSocket Integration:**

* Implemented `addToQueue` in `SongService`, enabling songs to be added to a session's queue, saving them to the database, and broadcasting the updated queue to clients via WebSocket. (`src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java` [[1]](diffhunk://#diff-843b2a0ff682f99ed650f11c6640b7f4a5784bd1cd3a768ada305d671ea368bcR75-R112) [[2]](diffhunk://#diff-843b2a0ff682f99ed650f11c6640b7f4a5784bd1cd3a768ada305d671ea368bcR27-R41)
* Updated `SessionService.joinSession` to broadcast the current queue and song to all connected clients upon a user joining a session, using `SongWebSocketPublisher`. (`src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java` [[1]](diffhunk://#diff-9e895e86815be3a850840785d3f0686b8c5973b00c3a2b9ee54c61b87abca723R153-R165) [[2]](diffhunk://#diff-9e895e86815be3a850840785d3f0686b8c5973b00c3a2b9ee54c61b87abca723R36-R44)
* Added a new `WebSocketConfig` to enable STOMP/WebSocket messaging with `/ws` endpoint and `/topic` broker, supporting real-time updates. (`src/main/java/ch/uzh/ifi/hase/soprafs26/config/WebSocketConfig.java` [src/main/java/ch/uzh/ifi/hase/soprafs26/config/WebSocketConfig.javaR1-R23](diffhunk://#diff-9c127d3e3cb3ce9d940255f77e4fa4866d40d9ae6e6206f740e74e84635afa4dR1-R23))

**DTO and API Enhancements:**

* Extended `SongPostDTO` to include required `spotifyId` and `durationMs` fields, and optional `albumArt`, enforcing validation for song additions. (`src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongPostDTO.java` [[1]](diffhunk://#diff-8229aaf35724c16e3ca0e7e7e9636f399f8412e592fb007307b42fe8293a2a1aR23-R35) [[2]](diffhunk://#diff-8229aaf35724c16e3ca0e7e7e9636f399f8412e592fb007307b42fe8293a2a1aL46-R52) [[3]](diffhunk://#diff-8229aaf35724c16e3ca0e7e7e9636f399f8412e592fb007307b42fe8293a2a1aR104-R124)
* Enabled the `/sessions/{sessionId}/songs` POST endpoint in `SongsController`, delegating to the new `addToQueue` method and returning the created song. (`src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java` [src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.javaL42-R46](diffhunk://#diff-be991424fed6a11f0c5ca87c4fcecbaa76795336e5399d769c47037dbab50e6fL42-R46))

**HTTP Client & Testing Support:**

* Added `http/critical-userstories.http`, a detailed, user-story-driven HTTP endpoint catalog for manual backend testing, covering all major flows and marking implementation status.
* Introduced `http/http-client.env.json` to provide environment variable sets for local and production testing with IntelliJ HTTP client.

**Service & Error Handling Improvements:**

* Updated `LyricsService` to use a dedicated `RestTemplate` bean with connection/read timeouts and improved error handling for timeouts and not found cases. (`src/main/java/ch/uzh/ifi/hase/soprafs26/service/LyricsService.java` [[1]](diffhunk://#diff-e8c101b097d1bc683457d225c39564050d5b5c6c90c8bd81b988de0884eadf29R3-R7) [[2]](diffhunk://#diff-e8c101b097d1bc683457d225c39564050d5b5c6c90c8bd81b988de0884eadf29L16-R32)
* Added configuration for two `RestTemplate` beans in `SpotifyConfig`: a primary default and a timeout-tuned one for lyrics fetching. (`src/main/java/ch/uzh/ifi/hase/soprafs26/config/SpotifyConfig.java` [src/main/java/ch/uzh/ifi/hase/soprafs26/config/SpotifyConfig.javaR3-R27](diffhunk://#diff-3609f51ad43d8ebc349e51d1f4f234e859f9bce53552f66e578d3512e3f7cd6cR3-R27))

**API Consistency:**

* Changed logout endpoint to expect the token in a `token` header instead of `Authorization`, aligning with other endpoints and simplifying client usage. (`src/main/java/ch/uzh/ifi/hase/soprafs26/controller/AuthController.java` [src/main/java/ch/uzh/ifi/hase/soprafs26/controller/AuthController.javaL50-R50](diffhunk://#diff-3204eacb83ae78138944fd2cc2a6d8800fa2759c960a78c4749d6f9a216f0d57L50-R50))