### PR TITLE
#48 broadcast lyrics text via websocket when the song starts playing

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -160,8 +160,11 @@ public class SessionService {
         saved.getPlaylist().stream()
                 .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
                 .findFirst()
-                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
-                .ifPresent(s -> songWebSocketPublisher.broadcastCurrentSong(sessionId, s));
+                .ifPresent(s -> {
+                    songWebSocketPublisher.broadcastCurrentSong(sessionId,
+                        DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes));
+                    songWebSocketPublisher.broadcastLyrics(sessionId, s.getLyrics());
+                });
 
         log.debug("User {} joined session {}", userId, sessionId);
         return saved;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/LyricsPayload.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/LyricsPayload.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs26.websocket;
+
+public class LyricsPayload {
+    private String lyrics;
+
+    public LyricsPayload() {}
+    public LyricsPayload(String lyrics) { this.lyrics = lyrics; }
+
+    public String getLyrics() { return lyrics; }
+    public void setLyrics(String lyrics) { this.lyrics = lyrics; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisher.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisher.java
@@ -16,4 +16,5 @@ public interface SongWebSocketPublisher {
     void broadcastCurrentSong(Long sessionId, SongGetDTO currentSong);
 
     void broadcastQueue(Long sessionId, List<SongGetDTO> queue);
+    void broadcastLyrics(Long sessionId, String lyrics);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImpl.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImpl.java
@@ -1,6 +1,6 @@
 package ch.uzh.ifi.hase.soprafs26.websocket;
 
-
+import ch.uzh.ifi.hase.soprafs26.websocket.LyricsPayload;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -23,6 +23,14 @@ public class SongWebSocketPublisherImpl implements SongWebSocketPublisher {
     @Override
     public void broadcastCurrentSong(Long sessionId, SongGetDTO currentSong) {
         messagingTemplate.convertAndSend("/topic/sessions/" + sessionId + "/currentSong", currentSong);
+    }
+
+    @Override
+    public void broadcastLyrics(Long sessionId, String lyrics) {
+        messagingTemplate.convertAndSend(
+            "/topic/sessions/" + sessionId + "/lyrics",
+            new LyricsPayload(lyrics)
+        );
     }
 }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImpl.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImpl.java
@@ -1,6 +1,5 @@
 package ch.uzh.ifi.hase.soprafs26.websocket;
 
-import ch.uzh.ifi.hase.soprafs26.websocket.LyricsPayload;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
added websocket lyrics broadcast infrastructure so that when a song starts playing, all connected clients receive the lyrics payload on /topic/sessions/{id}/lyrics.

websocket/LyricsPayload.java - New: { lyrics: "..." } payload class for WebSocket broadcast
websocket/SongWebSocketPublisher.java - Added broadcastLyrics(Long sessionId, String lyrics) to interface
websocket/SongWebSocketPublisherImpl.java - Implemented broadcastLyrics which sends LyricsPayload to /topic/sessions/{id}/lyrics via SimpMessagingTemplate
service/SessionService.java - added broadcastLyrics() call alongside existing broadcastCurrentSong() in joinSession() so late-joiners also receive lyrics