### PR TITLE
Rest implementation to send messages instantly upon joining

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 public class SongsController implements SongsApi {
@@ -49,11 +50,11 @@ public class SongsController implements SongsApi {
     // Returns 200 + SongGetDTO, 204 if nothing is playing, 404 if session not found
     @Override
     public ResponseEntity<SongGetDTO> sessionsSessionIdSongsCurrentGet(Long sessionId) {
-        SongGetDTO current = songService.getCurrentSong(sessionId);
-        if (current == null) {
-            return ResponseEntity.noContent().build(); 
+        Optional<SongGetDTO> current = songService.getCurrentSong(sessionId);
+        if (current.isEmpty()) {
+            return ResponseEntity.noContent().build();
         }
-        return ResponseEntity.ok(current);
+        return ResponseEntity.ok(current.get());
     }
 
     // POST /sessions/{sessionId}/songs/skip — Skip current song, admin only (S7)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
@@ -34,8 +34,7 @@ public class SongsController implements SongsApi {
     // Returns 200 + list of SongGetDTO
     @Override
     public ResponseEntity<List<SongGetDTO>> sessionsSessionIdSongsGet(Long sessionId) {
-        // TODO: delegate to songService.getQueue(sessionId)
-        throw new UnsupportedOperationException("Not implemented yet");
+        return ResponseEntity.ok(songService.getQueue(sessionId));
     }
 
     // POST /sessions/{sessionId}/songs — Add a song to the queue (S6, S10)
@@ -50,8 +49,11 @@ public class SongsController implements SongsApi {
     // Returns 200 + SongGetDTO, 204 if nothing is playing, 404 if session not found
     @Override
     public ResponseEntity<SongGetDTO> sessionsSessionIdSongsCurrentGet(Long sessionId) {
-        // TODO: delegate to songService.getCurrentSong(sessionId)
-        throw new UnsupportedOperationException("Not implemented yet");
+        SongGetDTO current = songService.getCurrentSong(sessionId);
+        if (current == null) {
+            return ResponseEntity.noContent().build(); 
+        }
+        return ResponseEntity.ok(current);
     }
 
     // POST /sessions/{sessionId}/songs/skip — Skip current song, admin only (S7)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -117,15 +117,14 @@ public class SongService {
     }
 
     @Transactional(readOnly = true)
-    public SongGetDTO getCurrentSong(Long sessionId) {
+    public Optional<SongGetDTO> getCurrentSong(Long sessionId) {
         Session session = sessionService.getSessionById(sessionId);
         Map<Long, Long> emptyVotes = Collections.emptyMap();
 
         return session.getPlaylist().stream()
                 .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
                 .findFirst()
-                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
-                .orElse(null); // null = no song playing → controller returns 204
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -115,4 +115,26 @@ public class SongService {
     void cacheLyrics(String spotifyId, String lyrics) {
         lyricsCache.put(spotifyId, Optional.ofNullable(lyrics));
     }
+
+    @Transactional(readOnly = true)
+    public SongGetDTO getCurrentSong(Long sessionId) {
+        Session session = sessionService.getSessionById(sessionId);
+        Map<Long, Long> emptyVotes = Collections.emptyMap();
+
+        return session.getPlaylist().stream()
+                .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
+                .findFirst()
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                .orElse(null); // null = no song playing → controller returns 204
+    }
+
+    @Transactional(readOnly = true)
+    public List<SongGetDTO> getQueue(Long sessionId) {
+        Session session = sessionService.getSessionById(sessionId);
+        Map<Long, Long> emptyVotes = Collections.emptyMap();
+
+        return session.getPlaylist().stream()
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                .toList();
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionsControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionsControllerTest.java
@@ -205,6 +205,8 @@ class SessionsControllerTest {
 
     @Test
     void sessionsSessionIdParticipantsUserIdDelete_validRequest_returns204() throws Exception {
+        given(userService.getUserByToken("valid-token")).willReturn(admin);
+
         mockMvc.perform(delete("/sessions/10/participants/1")
                         .header("token", "valid-token"))
                 .andExpect(status().isNoContent());


### PR DESCRIPTION
This pull request implements the backend logic for fetching the current song and the song queue for a session, and wires these methods into the `SongsController`. The main focus is on enabling the retrieval of the current song (with appropriate HTTP status codes) and the full song queue for a session.

**Backend logic implementation:**

* Added `getCurrentSong(Long sessionId)` and `getQueue(Long sessionId)` methods to `SongService`, which fetch the current song (the first unperformed song) and the entire playlist as `SongGetDTO` objects, respectively.

**Controller integration:**

* Updated `sessionsSessionIdSongsGet` in `SongsController` to return the song queue using `songService.getQueue(sessionId)`.
* Updated `sessionsSessionIdSongsCurrentGet` in `SongsController` to return the current song using `songService.getCurrentSong(sessionId)`, returning a 204 status if no song is currently playing.