### PR TITLE
feat: add POST /songs/next for automatic queue advancement

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
@@ -6,6 +6,9 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.service.SongService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -66,6 +69,14 @@ public class SongsController implements SongsApi {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 
+    // POST /sessions/{sessionId}/songs/next — advance to next song when current ends
+    // Marks the current song as performed, broadcasts next currentSong + queue
+    @PostMapping("/sessions/{sessionId}/songs/next")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void sessionsSessionIdSongsNextPost(@PathVariable Long sessionId) {
+        songService.nextSong(sessionId);
+    }
+
     // DELETE /sessions/{sessionId}/songs/{songId} — Remove a song from the queue, admin only (S7)
     // Returns 204 on success, 403 if not admin, 404 if session or song not found
     @Override
@@ -75,10 +86,9 @@ public class SongsController implements SongsApi {
     }
 
     // PUT /sessions/{sessionId}/songs/{songId}/played — Mark a song as played, admin only
-    // Returns 200 + updated SongGetDTO, 403 if not admin, 404 if session or song not found
+    // Stubbed as no-op 204 (advancement is now handled by POST /songs/next)
     @Override
     public ResponseEntity<SongGetDTO> sessionsSessionIdSongsSongIdPlayedPut(Long sessionId, Long songId) {
-        // TODO: verify caller is admin, delegate to songService.markAsPlayed(sessionId, songId)
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -93,6 +93,7 @@ public class SongService {
 
         // Broadcast updated queue (no votes yet → empty counts map)
         List<SongGetDTO> queue = session.getPlaylist().stream()
+                .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
                 .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
                 .toList();
         songWebSocketPublisher.broadcastQueue(sessionId, queue);
@@ -133,7 +134,39 @@ public class SongService {
         Map<Long, Long> emptyVotes = Collections.emptyMap();
 
         return session.getPlaylist().stream()
+                .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
                 .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
                 .toList();
+    }
+
+    @Transactional
+    public void nextSong(Long sessionId) {
+        Session session = sessionService.getSessionById(sessionId);
+        List<Song> playlist = session.getPlaylist();
+        Map<Long, Long> emptyVotes = Collections.emptyMap();
+
+        // Mark the current song (first unperformed) as performed
+        playlist.stream()
+                .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
+                .findFirst()
+                .ifPresent(s -> {
+                    s.markPerformed();
+                    songRepository.save(s);
+                });
+
+        // Find the next unperformed song
+        SongGetDTO next = playlist.stream()
+                .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
+                .findFirst()
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                .orElse(null);
+
+        // Broadcast new current song (null if queue exhausted) and updated queue
+        List<SongGetDTO> updatedQueue = playlist.stream()
+                .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                .toList();
+        songWebSocketPublisher.broadcastCurrentSong(sessionId, next);
+        songWebSocketPublisher.broadcastQueue(sessionId, updatedQueue);
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -17,8 +17,10 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.isNull;
 
 class SongServiceTest {
 
@@ -135,5 +137,81 @@ class SongServiceTest {
 
         assertNull(result.getLyrics());
         verify(songWebSocketPublisher).broadcastQueue(eq(2L), anyList());
+    }
+
+    @Test
+    void nextSong_advancesToNextUnperformedSong() {
+        Session session = new Session();
+
+        Song first = new Song();
+        first.setId(1L);
+        first.setSpotifyId("s1");
+        first.setTitle("First");
+        first.setArtist("Artist");
+        first.setDurationMs(180000);
+        first.setPerformed(false);
+        first.setSession(session);
+
+        Song second = new Song();
+        second.setId(2L);
+        second.setSpotifyId("s2");
+        second.setTitle("Second");
+        second.setArtist("Artist");
+        second.setDurationMs(200000);
+        second.setPerformed(false);
+        second.setSession(session);
+
+        session.getPlaylist().add(first);
+        session.getPlaylist().add(second);
+
+        when(sessionService.getSessionById(1L)).thenReturn(session);
+        when(songRepository.save(any(Song.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        songService.nextSong(1L);
+
+        assertTrue(first.getPerformed(), "first song should be marked performed");
+        assertFalse(second.getPerformed(), "second song should still be unperformed");
+
+        verify(songWebSocketPublisher).broadcastCurrentSong(eq(1L),
+                argThat(dto -> dto != null && "Second".equals(dto.getTitle())));
+        verify(songWebSocketPublisher).broadcastQueue(eq(1L),
+                argThat(queue -> queue.size() == 1 && "Second".equals(queue.get(0).getTitle())));
+    }
+
+    @Test
+    void nextSong_lastSong_broadcastsNullCurrentSong() {
+        Session session = new Session();
+
+        Song only = new Song();
+        only.setId(3L);
+        only.setSpotifyId("s3");
+        only.setTitle("Last");
+        only.setArtist("Artist");
+        only.setDurationMs(200000);
+        only.setPerformed(false);
+        only.setSession(session);
+
+        session.getPlaylist().add(only);
+
+        when(sessionService.getSessionById(2L)).thenReturn(session);
+        when(songRepository.save(any(Song.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        songService.nextSong(2L);
+
+        assertTrue(only.getPerformed());
+        verify(songWebSocketPublisher).broadcastCurrentSong(eq(2L), isNull());
+        verify(songWebSocketPublisher).broadcastQueue(eq(2L), argThat(List::isEmpty));
+    }
+
+    @Test
+    void nextSong_emptyPlaylist_broadcastsNullWithoutError() {
+        Session session = new Session(); // empty playlist
+        when(sessionService.getSessionById(3L)).thenReturn(session);
+
+        songService.nextSong(3L);
+
+        verify(songRepository, never()).save(any());
+        verify(songWebSocketPublisher).broadcastCurrentSong(eq(3L), isNull());
+        verify(songWebSocketPublisher).broadcastQueue(eq(3L), argThat(List::isEmpty));
     }
 }


### PR DESCRIPTION
  - nextSong() marks first unperformed song as performed, broadcasts next currentSong (null when queue empty) and updated queue via WebSocket
  - getQueue() and addToQueue() broadcast now filter to unperformed songs only
  - /played stub changed from 501 to 204 no-op
  - Fixes stale-list broadcast by filtering in-memory playlist directly