### PR TITLE
Migrate app.yaml from App Engine Standard to Flexible

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,8 +1,18 @@
-# https://cloud.google.com/appengine/docs/the-appengine-environments#comparing_high-level_features
-# https://cloud.google.com/appengine/docs/standard
+runtime: custom
+env: flex
 
-runtime: java17
-instance_class: F4_1G
+resources:
+  cpu: 1
+  memory_gb: 1.7
+  disk_size_gb: 10
 
-automatic_scaling:
-  max_instances: 1
+manual_scaling:
+  instances: 1
+
+liveness_check:
+  path: "/actuator/health"
+  initial_delay_sec: 300
+
+readiness_check:
+  path: "/actuator/health"
+  app_start_timeout_sec: 300

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'


### PR DESCRIPTION
Switches to runtime: custom + env: flex so the existing Dockerfile is used. Adds health check grace periods for Spring Boot startup time. Enables native WebSocket support.

Add Spring Boot Actuator for App Engine Flex health checks

Provides /actuator/health endpoint required by Flex liveness and readiness probes.

——

This pull request updates the `app.yaml` configuration to migrate the application from the App Engine Standard environment to the Flexible environment, while also customizing resource allocation and health checks.

**Environment migration and resource configuration:**

* Switched from App Engine Standard (`java17`) to Flexible environment by setting `runtime: custom` and `env: flex`, and removed the `instance_class` setting.
* Defined explicit resource allocations for CPU, memory, and disk size under the `resources` section.
* Changed scaling from `automatic_scaling` to `manual_scaling` with a fixed single instance.

**Health checks:**

* Added `liveness_check` and `readiness_check` configurations pointing to the `/actuator/health` endpoint, with specified initial delays and timeouts.