### PR TITLE
#33 Implement song deletion operation. Add tests and adjust openapi spec.

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
@@ -4,6 +4,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.service.SongService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,11 +15,13 @@ import java.util.Optional;
 
 @RestController
 public class SongsController implements SongsApi {
-
+    private static final String TOKEN_HEADER = "token";
     private final SongService songService;
+    private final HttpServletRequest request;
 
-    SongsController(SongService songService) {
+    SongsController(SongService songService, HttpServletRequest request) {
         this.songService = songService;
+        this.request = request;
     }
 
     // GET /songs/search?query= — Search songs via Spotify Web API (S11)
@@ -70,8 +73,9 @@ public class SongsController implements SongsApi {
     // Returns 204 on success, 403 if not admin, 404 if session or song not found
     @Override
     public ResponseEntity<Void> sessionsSessionIdSongsSongIdDelete(Long sessionId, Long songId) {
-        // TODO: verify caller is admin, delegate to songService.removeFromQueue(sessionId, songId)
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+        String token = request.getHeader(TOKEN_HEADER);
+        songService.deleteSongFromQueue(sessionId, songId, token);
+        return ResponseEntity.noContent().build();
     }
 
     // PUT /sessions/{sessionId}/songs/{songId}/played — Mark a song as played, admin only

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -30,14 +30,25 @@ public class SessionService {
     private final SessionRepository sessionRepository;
     private final UserRepository userRepository;
     private final SongWebSocketPublisher songWebSocketPublisher;
+    private final UserService userService;
 
     @Autowired
     public SessionService(SessionRepository sessionRepository,
                           UserRepository userRepository,
-                          SongWebSocketPublisher songWebSocketPublisher) {
+                          SongWebSocketPublisher songWebSocketPublisher, UserService userService) {
         this.sessionRepository = sessionRepository;
         this.userRepository = userRepository;
         this.songWebSocketPublisher = songWebSocketPublisher;
+        this.userService = userService;
+    }
+
+    public void verifyIsAdmin(Long sessionId, String token) {
+        User user = userService.getUserByToken(token);
+        Session session = getSessionById(sessionId);
+        if (!session.getAdmin().getId().equals(user.getId())) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN, "Only the session admin can perform this action");
+        }
     }
 
     /*

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -30,7 +30,6 @@ public class SongService {
     private final SessionService sessionService;
     private final SongWebSocketPublisher songWebSocketPublisher;
 
-    // ConcurrentHashMap doesn't allow null values, so we wrap in Optional
     private final Map<String, Optional<String>> lyricsCache = new ConcurrentHashMap<>();
 
     public SongService(SpotifyService spotifyService, LyricsService lyricsService,
@@ -156,10 +155,48 @@ public class SongService {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Song not found in this session");
         }
 
+        Optional<Song> currentSongBeforeDelete = session.getPlaylist().stream()
+                .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
+                .findFirst();
+
+        boolean deletedCurrentSong = currentSongBeforeDelete
+                .map(currentSong -> currentSong.getId().equals(songId))
+                .orElse(false);
+
         session.removeSong(songToDelete);
+        songRepository.delete(songToDelete);
 
         Map<Long, Long> emptyVotes = Collections.emptyMap();
+
+        if (deletedCurrentSong) {
+            // Check how many songs are actually left
+            List<Song> remainingQueue = session.getPlaylist().stream()
+                    .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
+                    .toList();
+
+            if (remainingQueue.size() >= 2) {
+                // TODO: Uncomment these 3 lines in the next issue once createVotingRound is implemented!
+                /* VotingRound newRound = votingService.createVotingRound(sessionId);
+                VotingRoundGetDTO roundDTO = DTOMapper.INSTANCE.toVotingRoundGetDTO(newRound, emptyVotes);
+                votingWebSocketPublisher.broadcastVotingRound(sessionId, roundDTO);
+                */
+
+                songWebSocketPublisher.broadcastCurrentSong(sessionId, null);
+                songWebSocketPublisher.broadcastLyrics(sessionId, null);
+
+            } else if (remainingQueue.size() == 1) {
+                Song nextSong = remainingQueue.get(0);
+                songWebSocketPublisher.broadcastCurrentSong(sessionId,
+                        DTOMapper.INSTANCE.toSongGetDTO(nextSong, emptyVotes));
+                songWebSocketPublisher.broadcastLyrics(sessionId, nextSong.getLyrics());
+
+            } else {
+                songWebSocketPublisher.broadcastCurrentSong(sessionId, null);
+                songWebSocketPublisher.broadcastLyrics(sessionId, null);
+            }
+        }
         List<SongGetDTO> queue = session.getPlaylist().stream()
+                .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
                 .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
                 .toList();
         songWebSocketPublisher.broadcastQueue(sessionId, queue);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -8,8 +8,10 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.SongPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Collections;
 import java.util.List;
@@ -136,4 +138,27 @@ public class SongService {
                 .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
                 .toList();
     }
+
+    @Transactional
+    public void deleteSongFromQueue(Long sessionId, Long songId, String token) {
+        sessionService.verifyIsAdmin(sessionId, token);
+        Session session = sessionService.getSessionById(sessionId);
+
+        Song songToDelete = songRepository.findById(songId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Song not found"));
+
+        if (!songToDelete.getSession().getId().equals(sessionId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Song not found in this session");
+        }
+
+        session.removeSong(songToDelete);
+
+        Map<Long, Long> emptyVotes = Collections.emptyMap();
+        List<SongGetDTO> queue = session.getPlaylist().stream()
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                .toList();
+        songWebSocketPublisher.broadcastQueue(sessionId, queue);
+    }
+
+
 }

--- a/src/main/resources/static/karaokee-openapi.json
+++ b/src/main/resources/static/karaokee-openapi.json
@@ -649,6 +649,9 @@
           "204" : {
             "description" : "Song removed"
           },
+          "401" : {
+            "description" : "Missing or invalid token"
+          },
           "403" : {
             "description" : "Only admin can remove songs"
           },

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SongsControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SongsControllerTest.java
@@ -17,10 +17,11 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -112,5 +113,56 @@ class SongsControllerTest {
                         .content("{\"spotifyId\":\"track123\",\"artist\":\"ABBA\"}")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void deleteSong_validRequest_returns204AndDelegatesToService() throws Exception {
+        willDoNothing().given(songService).deleteSongFromQueue(42L, 7L, "admin-token");
+
+        mockMvc.perform(delete("/sessions/42/songs/7")
+                        .header("token", "admin-token"))
+                .andExpect(status().isNoContent());
+
+        verify(songService).deleteSongFromQueue(42L, 7L, "admin-token");
+    }
+
+    @Test
+    void deleteSong_notAdmin_returns403() throws Exception {
+        willThrow(new ResponseStatusException(FORBIDDEN, "Only the session admin can perform this action"))
+                .given(songService).deleteSongFromQueue(eq(42L), eq(7L), any());
+
+        mockMvc.perform(delete("/sessions/42/songs/7")
+                        .header("token", "intruder-token"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteSong_songNotFound_returns404() throws Exception {
+        willThrow(new ResponseStatusException(NOT_FOUND, "Song not found"))
+                .given(songService).deleteSongFromQueue(eq(42L), eq(999L), any());
+
+        mockMvc.perform(delete("/sessions/42/songs/999")
+                        .header("token", "admin-token"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteSong_sessionNotFound_returns404() throws Exception {
+        willThrow(new ResponseStatusException(NOT_FOUND, "Session not found"))
+                .given(songService).deleteSongFromQueue(eq(99L), eq(7L), any());
+
+        mockMvc.perform(delete("/sessions/99/songs/7")
+                        .header("token", "admin-token"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteSong_songFromDifferentSession_returns404() throws Exception {
+        willThrow(new ResponseStatusException(NOT_FOUND, "Song not found in this session"))
+                .given(songService).deleteSongFromQueue(eq(42L), eq(7L), any());
+
+        mockMvc.perform(delete("/sessions/42/songs/7")
+                        .header("token", "admin-token"))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs26.service;
 
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.entity.Song;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SongRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongPostDTO;
@@ -12,8 +13,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -244,5 +248,116 @@ class SongServiceTest {
         verify(songRepository, never()).save(any());
         verify(songWebSocketPublisher).broadcastCurrentSong(eq(3L), isNull());
         verify(songWebSocketPublisher).broadcastQueue(eq(3L), argThat(List::isEmpty));
+    }
+
+    @Test
+    void deleteSongFromQueue_success_removesQueuedSongAndBroadcasts() {
+        User admin = new User();
+        admin.setId(1L);
+
+        Session session = new Session();
+        session.setId(1L);
+        session.setAdmin(admin);
+
+        Song currentSong = new Song();
+        currentSong.setId(10L);
+        currentSong.setTitle("Current Song");
+        currentSong.setPerformed(false);
+        currentSong.setSession(session);
+
+        Song songToDelete = new Song();
+        songToDelete.setId(20L);
+        songToDelete.setTitle("Queued Song");
+        songToDelete.setPerformed(false);
+        songToDelete.setSession(session);
+
+        session.getPlaylist().add(currentSong);
+        session.getPlaylist().add(songToDelete);
+
+        when(sessionService.getSessionById(1L)).thenReturn(session);
+        when(songRepository.findById(20L)).thenReturn(Optional.of(songToDelete));
+
+        songService.deleteSongFromQueue(1L, 20L, "test-token");
+
+        assertEquals(1, session.getPlaylist().size());
+        assertFalse(session.getPlaylist().contains(songToDelete));
+        verify(songRepository).delete(songToDelete);
+
+        // Broadcast updated queue
+        verify(songWebSocketPublisher).broadcastQueue(eq(1L), anyList());
+        // Should not broadcast new song to not disturb the one still playing
+        verify(songWebSocketPublisher, never()).broadcastCurrentSong(anyLong(), any());
+    }
+
+    @Test
+    void deleteSongFromQueue_success_deletesCurrentSongAndBroadcastsNew() {
+        User admin = new User();
+        admin.setId(1L);
+
+        Session session = new Session();
+        session.setId(1L);
+        session.setAdmin(admin);
+
+        Song currentSong = new Song();
+        currentSong.setId(10L);
+        currentSong.setTitle("Current Song");
+        currentSong.setPerformed(false);
+        currentSong.setSession(session);
+
+        Song nextSong = new Song();
+        nextSong.setId(20L);
+        nextSong.setTitle("Next Song");
+        nextSong.setPerformed(false);
+        nextSong.setSession(session);
+
+        session.getPlaylist().add(currentSong);
+        session.getPlaylist().add(nextSong);
+
+        when(sessionService.getSessionById(1L)).thenReturn(session);
+        when(songRepository.findById(10L)).thenReturn(Optional.of(currentSong));
+        songService.deleteSongFromQueue(1L, 10L, "test-token");
+
+        assertEquals(1, session.getPlaylist().size());
+        verify(songRepository).delete(currentSong);
+
+        // Broadcast the updated queue and the new current song
+        verify(songWebSocketPublisher).broadcastQueue(eq(1L), anyList());
+        verify(songWebSocketPublisher).broadcastCurrentSong(eq(1L),
+                argThat(dto -> dto != null && "Next Song".equals(dto.getTitle())));
+    }
+
+    @Test
+    void deleteSongFromQueue_throws404_whenSessionNotFound() {
+        when(sessionService.getSessionById(99L)).thenThrow(
+                new ResponseStatusException(org.springframework.http.HttpStatus.NOT_FOUND)
+        );
+
+        ResponseStatusException exception = assertThrows(
+                org.springframework.web.server.ResponseStatusException.class,
+                () -> songService.deleteSongFromQueue(99L, 10L, "test-token")
+        );
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+    }
+
+    @Test
+    void deleteSongFromQueue_throws404_whenSongNotInPlaylist() {
+        User admin = new User();
+        admin.setId(1L);
+
+        Session session = new Session();
+        session.setAdmin(admin);
+
+        Song someSong = new Song();
+        someSong.setId(10L);
+        session.getPlaylist().add(someSong);
+
+        when(sessionService.getSessionById(1L)).thenReturn(session);
+
+        // Delete song which is not in playlist
+        ResponseStatusException exception = assertThrows(
+                org.springframework.web.server.ResponseStatusException.class,
+                () -> songService.deleteSongFromQueue(1L, 99L, "test-token")
+        );
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
     }
 }


### PR DESCRIPTION
**#33 Implement DELETE /sessions/{id}/playlist/{songId} endpoint (admin only)**
- Implement song deletion functionality with automatic websocket update for users.
- Add tests to verify functionality
- Update swagger api spec to include 401 error