### PR TITLE
Fix Cloud Build timeout and skip redundant tests in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN chmod +x ./gradlew
 COPY build.gradle settings.gradle /app/
 COPY src /app/src
 # Build the server
-RUN ./gradlew clean build --no-daemon
+RUN ./gradlew clean build --no-daemon -x test
 
 # make image smaller by using multi stage build
 FROM eclipse-temurin:17-jdk

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,6 @@
 runtime: custom
 env: flex
+cloud_build_timeout: 1800s
 
 resources:
   cpu: 1


### PR DESCRIPTION
Tests already run in CI. Skipping them in the Docker build cuts build time significantly. Adding cloud_build_timeout: 1800s gives Flex up to 30 minutes to build the image, well above the 10-minute default.