### PR TITLE
#35 reaction message handler to receive and broadcast reactions

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/ReactionType.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/ReactionType.java
@@ -19,7 +19,7 @@ public enum ReactionType {
 
     LAUGH("LAUGH"),
 
-    SKULL("SKULL");
+    PARTY_POPPER("PARTY_POPPER");
 
     private final String value;
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ReactionMessageHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ReactionMessageHandler.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Controller;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
+import org.springframework.transaction.annotation.Transactional;
 
 @Controller
 public class ReactionMessageHandler {
@@ -31,6 +32,7 @@ public class ReactionMessageHandler {
         this.reactionPublisher = reactionPublisher;
     }
 
+    @Transactional(readOnly = true)
     @MessageMapping("/sessions/{sessionId}/reactions")
     public void handleReaction(@DestinationVariable Long sessionId,
                                @Payload Map<String, Object> payload) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ReactionMessageHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ReactionMessageHandler.java
@@ -1,0 +1,59 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ReactionGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ReactionPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
+import ch.uzh.ifi.hase.soprafs26.service.SessionService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import ch.uzh.ifi.hase.soprafs26.websocket.ReactionWebSocketPublisher;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+@Controller
+public class ReactionMessageHandler {
+
+    private final SessionService sessionService;
+    private final UserService userService;
+    private final ReactionWebSocketPublisher reactionPublisher;
+
+    public ReactionMessageHandler(SessionService sessionService,
+                                  UserService userService,
+                                  ReactionWebSocketPublisher reactionPublisher) {
+        this.sessionService = sessionService;
+        this.userService = userService;
+        this.reactionPublisher = reactionPublisher;
+    }
+
+    @MessageMapping("/sessions/{sessionId}/reactions")
+    public void handleReaction(@DestinationVariable Long sessionId,
+                               @Payload Map<String, Object> payload) {
+
+        Long userId = Long.valueOf(payload.get("userId").toString());
+        String type = payload.get("type").toString();
+
+        Set<User> participants = sessionService.getParticipants(sessionId);
+        User sender = participants.stream()
+                .filter(u -> u.getId().equals(userId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "User " + userId + " is not a participant of session " + sessionId));
+
+        ReactionGetDTO reaction = new ReactionGetDTO();
+        reaction.setType(ch.uzh.ifi.hase.soprafs26.constant.ReactionType.fromValue(type));
+        reaction.setSentAt(Instant.now());
+
+        UserGetDTO senderDTO = new UserGetDTO();
+        senderDTO.setId(sender.getId());
+        senderDTO.setUsername(sender.getUsername());
+        reaction.setSender(senderDTO);
+
+        reactionPublisher.broadcastReaction(sessionId, reaction);
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/ReactionWebSocketPublisherImpl.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/ReactionWebSocketPublisherImpl.java
@@ -1,0 +1,23 @@
+package ch.uzh.ifi.hase.soprafs26.websocket;
+
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ReactionGetDTO;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReactionWebSocketPublisherImpl implements ReactionWebSocketPublisher {
+
+    private static final String TOPIC_PREFIX = "/topic/sessions/";
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public ReactionWebSocketPublisherImpl(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    @Override
+    public void broadcastReaction(Long sessionId, ReactionGetDTO reaction) {
+        messagingTemplate.convertAndSend(
+                TOPIC_PREFIX + sessionId + "/reactions", reaction);
+    }
+}


### PR DESCRIPTION
Added WebSocket-based reaction handling so participants can send live emoji reactions during a session.
Two new files, no modifications to existing code:

ReactionWebSocketPublisherImpl.java:  implements the existing ReactionWebSocketPublisher interface, sends reactions to /topic/sessions/{id}/reactions via SimpMessagingTemplate
ReactionMessageHandler.java: @MessageMapping handler at /app/sessions/{id}/reactions, validates the sender is a session participant, builds a ReactionGetDTO with sender info and timestamp, then broadcasts to all subscribers