### PR TITLE
#52 Implement GET /sessions/{id}/review endpoint

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionsController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionsController.java
@@ -154,5 +154,19 @@ public class SessionsController implements SessionsApi {
         return ResponseEntity.noContent().build();
     }
 
-    // All other SessionsApi endpoints remain NOT_IMPLEMENTED until you override them here
+    /**
+     * GET /sessions/{sessionId}/review
+     * <p>
+     * Returns the list of performed songs for a completed session.
+     *
+     * @param sessionId target session (path variable)
+     * @return 200 + List<SongGetDTO> of performed songs in play order
+     */
+    @Override
+    public ResponseEntity<List<SongGetDTO>> sessionsSessionIdReviewGet(Long sessionId) {
+        List<SongGetDTO> review = sessionService.getSessionReview(sessionId);
+        return ResponseEntity.ok(review);
+    }
+
+    // All other SessionsApi endpoints remain NOT_IMPLEMENTED until you override them her
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -247,4 +247,30 @@ public class SessionService {
         log.debug("User {} fulfilled initial song requirement for session {}",
                 userId, sessionId);
     }
+
+
+    /**
+     * Returns the list of performed songs for a completed session (review screen).
+     * Songs are ordered by id (which corresponds to play order)
+     *
+     * @param sessionId the session to review
+     * @return list of performed songs as DTOs
+     * @throws ResponseStatusException 404 if session not found, 403 if not ENDED
+     */
+    @Transactional(readOnly = true)
+    public List<SongGetDTO> getSessionReview(Long sessionId) {
+        Session session = getSessionById(sessionId);
+
+        if (session.getStatus() != SessionStatus.ENDED) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN, "Session has not ended yet");
+        }
+
+        Map<Long, Long> emptyVotes = Collections.emptyMap();
+
+        return session.getPlaylist().stream()
+                .filter(s -> Boolean.TRUE.equals(s.getPerformed()))
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                .toList();
+    }
 }


### PR DESCRIPTION
SessionService.java - Added getSessionReview(Long sessionId):
Fetches the session (throws 404 if not found via existing getSessionById)
Throws 403 FORBIDDEN if session status is not ENDED
Filters the playlist for songs where performed == true
Maps to SongGetDTO using the existing DTOMapper.toSongGetDTO (with empty vote counts since votes are irrelevant post-session)

SessionsController.java - sessionsSessionIdReviewGet(Long sessionId):
Delegates to sessionService.getSessionReview(sessionId)
Returns 200 with the list