### PR TITLE
# 115 be implement broadcast real time vote counts to frontend on vote cast

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -64,6 +64,9 @@ public interface DTOMapper {
     @Mapping(source = "token", target = "token")
     UserTokenDTO convertEntityToUserTokenDTO(User user);
 
+    @Mapping(target = "status",      source = "round.status")
+    @Mapping(target = "startedAt",   source = "round.startsAt")
+    @Mapping(target = "endsAt",      source = "round.endsAt")
     @Mapping(target = "candidates", source = "candidates", qualifiedByName = "sortedByVotes")
     VotingRoundGetDTO toVotingRoundGetDTO(VotingRound round, @Context Map<Long, Long> counts);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
@@ -9,6 +9,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs26.websocket.VotingWebSocketPublisher;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,7 +68,9 @@ public class VotingService {
             throw new ResponseStatusException(HttpStatus.GONE, "Voting round is CLOSED");
         }
         // Voter is participant check
-        if (!round.getSession().getParticipants().contains(voter)) {
+        boolean isParticipant = round.getSession().getParticipants().stream()
+                .anyMatch(p -> p.getId().equals(voter.getId()));
+        if (!isParticipant) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a participant");
         }
 
@@ -87,7 +90,11 @@ public class VotingService {
         vote.setVotingRound(round);
         vote.setVoter(voter);
         vote.setVotedSong(song);
-        voteRepository.save(vote);
+        try {
+            voteRepository.saveAndFlush(vote);
+        } catch (DataIntegrityViolationException ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Already voted");
+        }
 
         Map<Long, Long> counts = getVoteCounts(round);
         VotingRoundGetDTO roundDTO = DTOMapper.INSTANCE.toVotingRoundGetDTO(round, counts);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
@@ -88,6 +88,10 @@ public class VotingService {
         vote.setVoter(voter);
         vote.setVotedSong(song);
         voteRepository.save(vote);
+
+        Map<Long, Long> counts = getVoteCounts(round);
+        VotingRoundGetDTO roundDTO = DTOMapper.INSTANCE.toVotingRoundGetDTO(round, counts);
+        votingWebSocketPublisher.broadcastVotingRound(sessionId, roundDTO);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -120,11 +120,12 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
 
         assertDoesNotThrow(() -> votingService.castVote(10L, 50L, 100L, voter));
 
-        verify(voteRepository, times(1)).save(any(Vote.class));
+        verify(voteRepository, times(1)).saveAndFlush(any(Vote.class));
     }
 
     // Check fields correctly set in vote
@@ -134,11 +135,12 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
 
         votingService.castVote(10L, 50L, 100L, voter);
 
-        verify(voteRepository).save(argThat(vote ->
+        verify(voteRepository).saveAndFlush(argThat(vote ->
                 vote.getVotingRound().equals(votingRound) &&
                         vote.getVoter().equals(voter) &&
                         vote.getVotedSong().equals(candidateSong)
@@ -156,7 +158,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 99L, 100L, voter));
 
         assertEquals(404, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -170,7 +172,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(999L, 50L, 100L, voter));
 
         assertEquals(400, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -185,7 +187,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, voter));
 
         assertEquals(410, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -199,7 +201,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, nonParticipant));
 
         assertEquals(403, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -214,7 +216,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 999L, voter));
 
         assertEquals(404, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -398,7 +400,7 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
         when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
 
         votingService.castVote(10L, 50L, 100L, voter);
@@ -417,7 +419,7 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
 
         VoteRepository.SongVoteCount count = mock(VoteRepository.SongVoteCount.class);
         when(count.getSongId()).thenReturn(100L);
@@ -447,7 +449,7 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, secondVoter)).thenReturn(false);
-        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
 
         VoteRepository.SongVoteCount count = mock(VoteRepository.SongVoteCount.class);
         when(count.getSongId()).thenReturn(100L);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -6,6 +6,8 @@ import ch.uzh.ifi.hase.soprafs26.repository.SongRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.VotingRoundRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.VotingWebSocketPublisher;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -389,5 +391,78 @@ class VotingServiceTest {
 
         verify(votingRoundRepository, never()).save(any());
         verify(songService, never()).broadcastVotingRoundSongWinner(any(), any());
+    }
+
+    @Test
+    void castVote_validInput_broadcastDtoHasStartedAtAndEndsAtSet() {
+        when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
+        when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
+        when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
+        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
+
+        votingService.castVote(10L, 50L, 100L, voter);
+
+        ArgumentCaptor<VotingRoundGetDTO> dtoCaptor = ArgumentCaptor.forClass(VotingRoundGetDTO.class);
+        verify(votingWebSocketPublisher).broadcastVotingRound(eq(10L), dtoCaptor.capture());
+
+        VotingRoundGetDTO dto = dtoCaptor.getValue();
+        assertNotNull(dto.getStartedAt(), "startedAt must be mapped from entity startsAt");
+        assertNotNull(dto.getEndsAt(), "endsAt must be mapped from entity endsAt");
+        assertEquals(VotingStatus.OPEN, dto.getStatus());
+    }
+
+    @Test
+    void castVote_validInput_broadcastDtoContainsUpdatedCount() {
+        when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
+        when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
+        when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
+        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+
+        VoteRepository.SongVoteCount count = mock(VoteRepository.SongVoteCount.class);
+        when(count.getSongId()).thenReturn(100L);
+        when(count.getCount()).thenReturn(1L);
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of(count));
+
+        votingService.castVote(10L, 50L, 100L, voter);
+
+        ArgumentCaptor<VotingRoundGetDTO> dtoCaptor = ArgumentCaptor.forClass(VotingRoundGetDTO.class);
+        verify(votingWebSocketPublisher).broadcastVotingRound(eq(10L), dtoCaptor.capture());
+
+        SongGetDTO votedSong = dtoCaptor.getValue().getCandidates().stream()
+                .filter(s -> s.getId().equals(100L))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(1, votedSong.getCurrentVoteCount());
+    }
+
+    @Test
+    void castVote_secondVoter_broadcastDtoShowsAggregatedCount() {
+        User secondVoter = new User();
+        secondVoter.setId(3L);
+        secondVoter.setUsername("singer2");
+        secondVoter.setToken("voter2-token");
+        session.addParticipant(secondVoter);
+
+        when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
+        when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
+        when(voteRepository.existsByVotingRoundAndVoter(votingRound, secondVoter)).thenReturn(false);
+        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+
+        VoteRepository.SongVoteCount count = mock(VoteRepository.SongVoteCount.class);
+        when(count.getSongId()).thenReturn(100L);
+        when(count.getCount()).thenReturn(2L);
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of(count));
+
+        votingService.castVote(10L, 50L, 100L, secondVoter);
+
+        ArgumentCaptor<VotingRoundGetDTO> dtoCaptor = ArgumentCaptor.forClass(VotingRoundGetDTO.class);
+        verify(votingWebSocketPublisher).broadcastVotingRound(eq(10L), dtoCaptor.capture());
+
+        SongGetDTO votedSong = dtoCaptor.getValue().getCandidates().stream()
+                .filter(s -> s.getId().equals(100L))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(2, votedSong.getCurrentVoteCount());
     }
 }


### PR DESCRIPTION
#115 [BE] Implement Broadcast Real-Time Vote Counts to Frontend on Vote Cast

- Fixed DTOMapper to correctly transmit startedAt
- Implement broadcasting the new votingRoundDTO to all participants when a vote is casted to correctly update the vote count on the front end
- Add tests to verify implementation
