### PR TITLE
# 119 be implement get sessionssessionidvotingrounds

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/VotingController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/VotingController.java
@@ -33,8 +33,7 @@ public class VotingController implements VotingApi {
     // Returns 200 + list of VotingRoundGetDTO
     @Override
     public ResponseEntity<List<VotingRoundGetDTO>> sessionsSessionIdVotingRoundsGet(Long sessionId) {
-        // TODO: delegate to votingService.getRounds(sessionId)
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+        return ResponseEntity.ok(votingService.getRoundsForSession(sessionId));
     }
 
     // GET /sessions/{sessionId}/votingRounds/{roundId} — Get a specific voting round (S14)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
@@ -16,4 +16,5 @@ public interface VotingRoundRepository extends JpaRepository<VotingRound, Long> 
     List<VotingRound> findBySessionAndStatus(Session session, VotingStatus status);
     @Query("SELECT vr FROM VotingRound vr LEFT JOIN FETCH vr.candidates WHERE vr.id = :id")
     Optional<VotingRound> findByIdWithCandidates(@Param("id") Long id);
+    List<VotingRound> findBySessionOrderByStartsAtAsc(Session session);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -147,12 +147,10 @@ public class SessionService {
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, USER_NOT_FOUND));
 
-        boolean isNewParticipant = !session.getParticipants().contains(user);
-
         // Set.add() is a no-op when user is already present → idempotent
         session.addParticipant(user);
 
-        if (isNewParticipant) {
+        if (session.getStatus() == SessionStatus.CREATED && !hasContributedSong(session, user)) {
             session.addToPendingInitialSong(user);
         }
 
@@ -177,6 +175,11 @@ public class SessionService {
         return saved;
     }
 
+    private boolean hasContributedSong(Session session, User user) {
+        return session.getPlaylist().stream()
+                .anyMatch(s -> s.getAddedBy() != null
+                        && s.getAddedBy().getId().equals(user.getId()));
+    }
 
     /**
      * Remove a user from a session's participant list (soft-leave).

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
@@ -215,4 +215,16 @@ public class VotingService {
         moveWinnerToFrontOfQueue(sessionId, votingRoundSongWinner);
         songService.broadcastVotingRoundSongWinner(sessionId, votingRoundSongWinner);
     }
+
+    @Transactional(readOnly = true)
+    public List<VotingRoundGetDTO> getRoundsForSession(Long sessionId) {
+        Session session = sessionService.getSessionById(sessionId);
+        List<VotingRound> rounds = votingRoundRepository.findBySessionOrderByStartsAtAsc(session);
+        return rounds.stream()
+                .map(r -> {
+                    Map<Long, Long> counts = getVoteCounts(r);
+                    return DTOMapper.INSTANCE.toVotingRoundGetDTO(r, counts);
+                })
+                .toList();
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/VotingControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/VotingControllerTest.java
@@ -5,6 +5,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.VotingRound;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.VotePostDTO;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import ch.uzh.ifi.hase.soprafs26.service.VotingService;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,7 @@ import tools.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -27,6 +29,8 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @WebMvcTest(VotingController.class)
 class VotingControllerTest {
@@ -237,6 +241,49 @@ class VotingControllerTest {
 
         verify(votingService).getVotingRound(99L, 50L);
         verify(votingService, never()).getVoteCounts(any());
+    }
+
+    @Test
+    void getVotingRounds_noRounds_returns200WithEmptyArray() throws Exception {
+        given(votingService.getRoundsForSession(10L)).willReturn(List.of());
+
+        mockMvc.perform(get("/sessions/10/votingRounds")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+
+        verify(votingService).getRoundsForSession(10L);
+    }
+
+    @Test
+    void getVotingRounds_multipleRounds_returns200WithList() throws Exception {
+        VotingRoundGetDTO dto1 = new VotingRoundGetDTO();
+        dto1.setId(40L);
+        VotingRoundGetDTO dto2 = new VotingRoundGetDTO();
+        dto2.setId(50L);
+
+        given(votingService.getRoundsForSession(10L)).willReturn(List.of(dto1, dto2));
+
+        mockMvc.perform(get("/sessions/10/votingRounds")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(40))
+                .andExpect(jsonPath("$[1].id").value(50));
+
+        verify(votingService).getRoundsForSession(10L);
+    }
+
+    @Test
+    void getVotingRounds_sessionNotFound_returns404() throws Exception {
+        given(votingService.getRoundsForSession(999L))
+                .willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found"));
+
+        mockMvc.perform(get("/sessions/999/votingRounds")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+
+        verify(votingService).getRoundsForSession(999L);
     }
 
     private String asJsonString(final Object object) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -6,6 +6,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
+import ch.uzh.ifi.hase.soprafs26.entity.Song;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -198,6 +199,60 @@ class SessionServiceTest {
         verify(sessionRepository, never()).save(any());
     }
 
+    @Test
+    void joinSession_rejoinBeforeAddingSong_reAddsToPendingInitialSong() {
+        session.addParticipant(participant);
+        assertFalse(session.isPendingInitialSong(participant),
+                "Pre-condition: participant should not yet be flagged as pending");
+        assertTrue(session.getPlaylist().isEmpty(),
+                "Pre-condition: participant has not contributed a song");
+        assertEquals(SessionStatus.CREATED, session.getStatus(),
+                "Pre-condition: session is still in lobby phase");
+
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.joinSession(10L, "482910", 2L);
+
+        assertTrue(session.isPendingInitialSong(participant),
+                "Rejoin without a contributed song must re-add the user to pendingInitialSong");
+    }
+
+    @Test
+    void joinSession_rejoinAfterAddingSong_doesNotReAddToPendingInitialSong() {
+        session.addParticipant(participant);
+
+        Song contributed = new Song();
+        contributed.setId(500L);
+        contributed.setAddedBy(participant);
+        contributed.setSession(session);
+        session.addSong(contributed);
+
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.joinSession(10L, "482910", 2L);
+
+        assertFalse(session.isPendingInitialSong(participant),
+                "Rejoin after a contributed song must NOT re-add the user to pendingInitialSong");
+    }
+
+    @Test
+    void joinSession_rejoinAfterSessionStarted_doesNotReAddToPendingInitialSong() {
+        session.addParticipant(participant);
+        session.setStatus(SessionStatus.ACTIVE);
+
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.joinSession(10L, "482910", 2L);
+
+        assertFalse(session.isPendingInitialSong(participant),
+                "Rejoin after the session has started must NOT re-flag pendingInitialSong");
+    }
 
     // leaveSession
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -7,7 +7,6 @@ import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.VotingRoundRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.VotingWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -120,11 +119,12 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
 
         assertDoesNotThrow(() -> votingService.castVote(10L, 50L, 100L, voter));
 
-        verify(voteRepository, times(1)).save(any(Vote.class));
+        verify(voteRepository, times(1)).saveAndFlush(any(Vote.class));
     }
 
     // Check fields correctly set in vote
@@ -134,11 +134,11 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
 
         votingService.castVote(10L, 50L, 100L, voter);
 
-        verify(voteRepository).save(argThat(vote ->
+        verify(voteRepository).saveAndFlush(argThat(vote ->
                 vote.getVotingRound().equals(votingRound) &&
                         vote.getVoter().equals(voter) &&
                         vote.getVotedSong().equals(candidateSong)
@@ -156,7 +156,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 99L, 100L, voter));
 
         assertEquals(404, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -170,7 +170,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(999L, 50L, 100L, voter));
 
         assertEquals(400, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -185,7 +185,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, voter));
 
         assertEquals(410, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -199,7 +199,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, nonParticipant));
 
         assertEquals(403, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -214,7 +214,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 999L, voter));
 
         assertEquals(404, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -229,7 +229,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 200L, voter));
 
         assertEquals(400, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -245,7 +245,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, voter));
 
         assertEquals(409, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -120,12 +120,11 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
-        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
+        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
 
         assertDoesNotThrow(() -> votingService.castVote(10L, 50L, 100L, voter));
 
-        verify(voteRepository, times(1)).saveAndFlush(any(Vote.class));
+        verify(voteRepository, times(1)).save(any(Vote.class));
     }
 
     // Check fields correctly set in vote
@@ -135,12 +134,11 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
-        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
+        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
 
         votingService.castVote(10L, 50L, 100L, voter);
 
-        verify(voteRepository).saveAndFlush(argThat(vote ->
+        verify(voteRepository).save(argThat(vote ->
                 vote.getVotingRound().equals(votingRound) &&
                         vote.getVoter().equals(voter) &&
                         vote.getVotedSong().equals(candidateSong)
@@ -158,7 +156,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 99L, 100L, voter));
 
         assertEquals(404, ex.getStatusCode().value());
-        verify(voteRepository, never()).saveAndFlush(any());
+        verify(voteRepository, never()).save(any());
     }
 
 
@@ -172,7 +170,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(999L, 50L, 100L, voter));
 
         assertEquals(400, ex.getStatusCode().value());
-        verify(voteRepository, never()).saveAndFlush(any());
+        verify(voteRepository, never()).save(any());
     }
 
 
@@ -187,7 +185,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, voter));
 
         assertEquals(410, ex.getStatusCode().value());
-        verify(voteRepository, never()).saveAndFlush(any());
+        verify(voteRepository, never()).save(any());
     }
 
 
@@ -201,7 +199,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, nonParticipant));
 
         assertEquals(403, ex.getStatusCode().value());
-        verify(voteRepository, never()).saveAndFlush(any());
+        verify(voteRepository, never()).save(any());
     }
 
 
@@ -216,7 +214,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 999L, voter));
 
         assertEquals(404, ex.getStatusCode().value());
-        verify(voteRepository, never()).saveAndFlush(any());
+        verify(voteRepository, never()).save(any());
     }
 
 
@@ -393,6 +391,62 @@ class VotingServiceTest {
 
         verify(votingRoundRepository, never()).save(any());
         verify(songService, never()).broadcastVotingRoundSongWinner(any(), any());
+    }
+
+    @Test
+    void getRoundsForSession_noRounds_returnsEmptyList() {
+        when(sessionService.getSessionById(10L)).thenReturn(session);
+        when(votingRoundRepository.findBySessionOrderByStartsAtAsc(session))
+                .thenReturn(List.of());
+
+        List<VotingRoundGetDTO> result = votingService.getRoundsForSession(10L);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(voteRepository, never()).countVotesPerSong(any());
+    }
+
+    @Test
+    void getRoundsForSession_multipleRounds_returnsAllOrderedWithCounts() {
+        VotingRound earlier = new VotingRound();
+        earlier.setId(40L);
+        earlier.setSession(session);
+        earlier.setStatus(VotingStatus.CLOSED);
+        earlier.setStartsAt(LocalDateTime.now().minusMinutes(5));
+        earlier.setEndsAt(LocalDateTime.now().minusMinutes(4));
+        earlier.getCandidates().add(candidateSong);
+
+        when(sessionService.getSessionById(10L)).thenReturn(session);
+        when(votingRoundRepository.findBySessionOrderByStartsAtAsc(session))
+                .thenReturn(List.of(earlier, votingRound));
+
+        VoteRepository.SongVoteCount earlierCount = mock(VoteRepository.SongVoteCount.class);
+        when(earlierCount.getSongId()).thenReturn(100L);
+        when(earlierCount.getCount()).thenReturn(3L);
+        when(voteRepository.countVotesPerSong(earlier)).thenReturn(List.of(earlierCount));
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
+
+        List<VotingRoundGetDTO> result = votingService.getRoundsForSession(10L);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(40L, result.get(0).getId());
+        assertEquals(50L, result.get(1).getId());
+        verify(voteRepository, times(1)).countVotesPerSong(earlier);
+        verify(voteRepository, times(1)).countVotesPerSong(votingRound);
+    }
+
+    @Test
+    void getRoundsForSession_sessionNotFound_throwsNotFound() {
+        when(sessionService.getSessionById(999L))
+                .thenThrow(new ResponseStatusException(
+                        org.springframework.http.HttpStatus.NOT_FOUND, "Session not found"));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> votingService.getRoundsForSession(999L));
+
+        assertEquals(404, ex.getStatusCode().value());
+        verify(votingRoundRepository, never()).findBySessionOrderByStartsAtAsc(any());
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -7,6 +7,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.VotingRoundRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.VotingWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -136,6 +136,7 @@ class VotingServiceTest {
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
         when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
 
         votingService.castVote(10L, 50L, 100L, voter);
 


### PR DESCRIPTION
#119 Implement GET /sessions/{sessionId}/votingRounds

- Adds GET /sessions/{sessionId}/votingRounds (returns all rounds, or [] if none).
- Fixes joinSession to re-flag pendingInitialSong when a user rejoins before contributing a song.