### PR TITLE
#121 Implement SessionWebSocketPublisherImpl and update session service

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -15,8 +15,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
+import ch.uzh.ifi.hase.soprafs26.websocket.SessionWebSocketPublisher;
 
 import java.util.*;
+
 
 @Service
 @Transactional
@@ -30,15 +33,17 @@ public class SessionService {
     private final SessionRepository sessionRepository;
     private final UserRepository userRepository;
     private final SongWebSocketPublisher songWebSocketPublisher;
+    private final SessionWebSocketPublisher sessionWebSocketPublisher;
     private final UserService userService;
 
     @Autowired
     public SessionService(SessionRepository sessionRepository,
                           UserRepository userRepository,
-                          SongWebSocketPublisher songWebSocketPublisher, UserService userService) {
+                          SongWebSocketPublisher songWebSocketPublisher, SessionWebSocketPublisher sessionWebSocketPublisher, UserService userService) {
         this.sessionRepository = sessionRepository;
         this.userRepository = userRepository;
         this.songWebSocketPublisher = songWebSocketPublisher;
+        this.sessionWebSocketPublisher = sessionWebSocketPublisher;
         this.userService = userService;
     }
 
@@ -113,7 +118,10 @@ public class SessionService {
         }
 
         session.setStatus(newStatus);
-        return sessionRepository.save(session);
+        Session saved = sessionRepository.save(session);
+        sessionWebSocketPublisher.broadcastSessionStatus(sessionId,
+                DTOMapper.INSTANCE.convertEntityToSessionGetDTO(saved));
+        return saved;
     }
 
 
@@ -172,6 +180,11 @@ public class SessionService {
                             DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes));
                     songWebSocketPublisher.broadcastLyrics(sessionId, s.getLyrics());
                 });
+        
+        List<UserGetDTO> participantDTOs = saved.getParticipants().stream()
+                .map(DTOMapper.INSTANCE::convertEntityToUserGetDTO)
+                .toList();
+        sessionWebSocketPublisher.broadcastParticipants(sessionId, participantDTOs);
 
         log.debug("User {} joined session {}", userId, sessionId);
         return saved;
@@ -201,7 +214,13 @@ public class SessionService {
                         HttpStatus.NOT_FOUND, "Session or participant not found"));
 
         session.removeParticipant(user);
-        sessionRepository.save(session);
+        Session saved = sessionRepository.save(session);
+
+        List<UserGetDTO> participantDTOs = saved.getParticipants().stream()
+                .map(DTOMapper.INSTANCE::convertEntityToUserGetDTO)
+                .toList();
+        sessionWebSocketPublisher.broadcastParticipants(sessionId, participantDTOs);
+        
         log.debug("User {} left session {}", userId, sessionId);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SessionWebSocketPublisherImpl.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SessionWebSocketPublisherImpl.java
@@ -1,0 +1,29 @@
+package ch.uzh.ifi.hase.soprafs26.websocket;
+
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class SessionWebSocketPublisherImpl implements SessionWebSocketPublisher {
+
+    private static final String TOPIC_PREFIX = "/topic/sessions/";
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public SessionWebSocketPublisherImpl(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    @Override
+    public void broadcastSessionStatus(Long sessionId, SessionGetDTO session) {
+        messagingTemplate.convertAndSend(TOPIC_PREFIX + sessionId + "/status", session);
+    }
+
+    @Override
+    public void broadcastParticipants(Long sessionId, List<UserGetDTO> participants) {
+        messagingTemplate.convertAndSend(TOPIC_PREFIX + sessionId + "/participants", participants);
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -23,6 +23,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyList;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
+
 @ExtendWith(MockitoExtension.class)
 class SessionServiceTest {
 
@@ -356,5 +360,40 @@ class SessionServiceTest {
                 () -> sessionService.getParticipants(99L));
 
         assertEquals(404, ex.getStatusCode().value());
+    }
+
+
+    @Test
+    void updateSessionStatus_broadcastsStatusViaWebSocket() {
+        session.setStatus(SessionStatus.CREATED);
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.updateSessionStatus(10L, SessionStatus.ACTIVE, admin.getId());
+
+        verify(sessionWebSocketPublisher).broadcastSessionStatus(eq(10L), any(SessionGetDTO.class));
+    }
+
+    @Test
+    void joinSession_broadcastsParticipantsViaWebSocket() {
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.joinSession(10L, "482910", 2L);
+
+        verify(sessionWebSocketPublisher).broadcastParticipants(eq(10L), anyList());
+    }
+
+    @Test
+    void leaveSession_broadcastsParticipantsViaWebSocket() {
+        session.addParticipant(participant);
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.leaveSession(10L, 2L);
+
+        verify(sessionWebSocketPublisher).broadcastParticipants(eq(10L), anyList());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -6,6 +6,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
+import ch.uzh.ifi.hase.soprafs26.websocket.SessionWebSocketPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +33,9 @@ class SessionServiceTest {
 
     @Mock
     private SongWebSocketPublisher songWebSocketPublisher;
+
+    @Mock
+    private SessionWebSocketPublisher sessionWebSocketPublisher;
 
     @InjectMocks
     private SessionService sessionService;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SessionWebSocketPublisherImplTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SessionWebSocketPublisherImplTest.java
@@ -1,0 +1,38 @@
+package ch.uzh.ifi.hase.soprafs26.websocket;
+
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SessionWebSocketPublisherImplTest {
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private SessionWebSocketPublisherImpl publisher;
+
+    @Test
+    void broadcastSessionStatus_sendsToCorrectTopic() {
+        SessionGetDTO dto = new SessionGetDTO();
+        publisher.broadcastSessionStatus(42L, dto);
+        verify(messagingTemplate).convertAndSend("/topic/sessions/42/status", dto);
+    }
+
+    @Test
+    void broadcastParticipants_sendsToCorrectTopic() {
+        List<UserGetDTO> participants = List.of(new UserGetDTO());
+        publisher.broadcastParticipants(42L, participants);
+        verify(messagingTemplate).convertAndSend("/topic/sessions/42/participants", participants);
+    }
+}


### PR DESCRIPTION
When the admin changes session status (start/pause/end), a broadcast is sent to /topic/sessions/{id}/status with the updated SessionGetDTO
When a user joins a session, a broadcast is sent to /topic/sessions/{id}/participants with the updated participant list
When a user leaves a session, a broadcast is sent to /topic/sessions/{id}/participants with the updated participant list