### PR TITLE
Modified voting

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -48,6 +48,7 @@ public interface DTOMapper {
     @Mapping(source = "admin", target = "admin")
     @Mapping(source = "participants", target = "participants")
     @Mapping(source = "createdAt", target = "createdAt")
+    @Mapping(target = "requiresSongSelection", ignore = true)
     SessionGetDTO convertEntityToSessionGetDTO(Session session);
 
     default OffsetDateTime map(LocalDateTime localDateTime) {
@@ -66,15 +67,16 @@ public interface DTOMapper {
     @Mapping(target = "status",      source = "round.status")
     @Mapping(target = "startedAt",   source = "round.startsAt")
     @Mapping(target = "endsAt",      source = "round.endsAt")
-    @Mapping(target = "candidates", source = "candidates", qualifiedByName = "sortedByVotes")
+    @Mapping(target = "candidates", source = "candidates", qualifiedByName = "candidatesWithVoteCounts")
+    @Mapping(target = "roundNumber", ignore = true)
     VotingRoundGetDTO toVotingRoundGetDTO(VotingRound round, @Context Map<Long, Long> counts);
 
     @Mapping(target = "currentVoteCount", expression = "java(counts.getOrDefault(song.getId(), 0L).intValue())")
     @Mapping(target = "durationSeconds", expression = "java(song.getDurationMs() != null ? song.getDurationMs() / 1000 : null)")
     SongGetDTO toSongGetDTO(Song song, @Context Map<Long, Long> counts);
 
-    @Named("sortedByVotes")
-    default List<SongGetDTO> sortedByVotes(List<Song> songs, @Context Map<Long, Long> counts) {
+    @Named("candidatesWithVoteCounts")
+    default List<SongGetDTO> candidatesWithVoteCounts(List<Song> songs, @Context Map<Long, Long> counts) {
         return songs.stream()
                 .map(s -> toSongGetDTO(s, counts))
                 .toList();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -14,7 +14,6 @@ import org.mapstruct.factory.Mappers;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -78,7 +77,6 @@ public interface DTOMapper {
     default List<SongGetDTO> sortedByVotes(List<Song> songs, @Context Map<Long, Long> counts) {
         return songs.stream()
                 .map(s -> toSongGetDTO(s, counts))
-                .sorted(Comparator.comparingInt(SongGetDTO::getCurrentVoteCount).reversed())
                 .toList();
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -123,7 +123,7 @@ public class SessionService {
 
         session.setStatus(newStatus);
         Session savedSession = sessionRepository.save(session);
-        if (current == SessionStatus.CREATED) {
+        if (current == SessionStatus.CREATED && newStatus == SessionStatus.ACTIVE) {
             songService.promoteNextSong(sessionId, session);
         }
         sessionWebSocketPublisher.broadcastSessionStatus(sessionId,
@@ -281,16 +281,16 @@ public class SessionService {
         return session.isPendingInitialSong(user);
     }
 
-//    public void markInitialSongAdded(Long sessionId, Long userId) {
-//        Session session = getSessionById(sessionId);
-//        User user = userRepository.findById(userId)
-//                .orElseThrow(() -> new ResponseStatusException(
-//                        HttpStatus.NOT_FOUND, USER_NOT_FOUND));
-//        session.removeFromPendingInitialSong(user);
-//        sessionRepository.save(session);
-//        log.debug("User {} fulfilled initial song requirement for session {}",
-//                userId, sessionId);
-//    }
+    public void markInitialSongAdded(Long sessionId, Long userId) {
+        Session session = getSessionById(sessionId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, USER_NOT_FOUND));
+        session.removeFromPendingInitialSong(user);
+        sessionRepository.save(session);
+        log.debug("User {} fulfilled initial song requirement for session {}",
+                userId, sessionId);
+    }
 
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -123,7 +123,7 @@ public class SessionService {
 
         session.setStatus(newStatus);
         Session savedSession = sessionRepository.save(session);
-        if (current == SessionStatus.CREATED && newStatus == SessionStatus.ACTIVE) {
+        if (current == SessionStatus.CREATED) {
             songService.promoteNextSong(sessionId, session);
         }
         sessionWebSocketPublisher.broadcastSessionStatus(sessionId,
@@ -159,7 +159,7 @@ public class SessionService {
         }
 
         if (session.getStatus() == SessionStatus.ENDED) {
-            throw new ResponseStatusException(HttpStatus.GONE, "Session has already ended");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Session has already ended");
         }
 
         User user = userRepository.findById(userId)
@@ -281,16 +281,16 @@ public class SessionService {
         return session.isPendingInitialSong(user);
     }
 
-    public void markInitialSongAdded(Long sessionId, Long userId) {
-        Session session = getSessionById(sessionId);
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, USER_NOT_FOUND));
-        session.removeFromPendingInitialSong(user);
-        sessionRepository.save(session);
-        log.debug("User {} fulfilled initial song requirement for session {}",
-                userId, sessionId);
-    }
+//    public void markInitialSongAdded(Long sessionId, Long userId) {
+//        Session session = getSessionById(sessionId);
+//        User user = userRepository.findById(userId)
+//                .orElseThrow(() -> new ResponseStatusException(
+//                        HttpStatus.NOT_FOUND, USER_NOT_FOUND));
+//        session.removeFromPendingInitialSong(user);
+//        sessionRepository.save(session);
+//        log.debug("User {} fulfilled initial song requirement for session {}",
+//                userId, sessionId);
+//    }
 
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -158,6 +158,10 @@ public class SessionService {
                     HttpStatus.BAD_REQUEST, "Invalid game pin");
         }
 
+        if (session.getStatus() == SessionStatus.ENDED) {
+            throw new ResponseStatusException(HttpStatus.GONE, "Session has already ended");
+        }
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, USER_NOT_FOUND));

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -224,10 +224,10 @@ public class SongService {
     }
 
     @Transactional(readOnly = true)
-    public void broadcastVotingRoundSongWinner(Long sessionId, Song winner) {
+    public void broadcastVotingRoundSongWinner(Long sessionId, Song winner, Map<Long, Long> voteCounts) {
         Session session = sessionService.getSessionById(sessionId);
         Map<Long, Long> emptyVotes = Collections.emptyMap();
-        SongGetDTO nextSong = DTOMapper.INSTANCE.toSongGetDTO(winner, emptyVotes);
+        SongGetDTO nextSong = DTOMapper.INSTANCE.toSongGetDTO(winner, voteCounts);
 
         List<SongGetDTO> remainingQueue = session.getPlaylist().stream()
                 .filter(song -> !Boolean.TRUE.equals(song.getPerformed()))

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
@@ -139,7 +139,7 @@ public class VotingService {
             return;
         }
         if (playlist.size() == 1) {
-            songService.broadcastVotingRoundSongWinner(sessionId, playlist.get(0));
+            songService.broadcastVotingRoundSongWinner(sessionId, playlist.get(0), Collections.emptyMap());
             return;
         }
 
@@ -215,7 +215,7 @@ public class VotingService {
 
         Song votingRoundSongWinner = winnerCandidates.get(random.nextInt(winnerCandidates.size()));
         moveWinnerToFrontOfQueue(sessionId, votingRoundSongWinner);
-        songService.broadcastVotingRoundSongWinner(sessionId, votingRoundSongWinner);
+        songService.broadcastVotingRoundSongWinner(sessionId, votingRoundSongWinner, finalCounts);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/static/karaokee-openapi.json
+++ b/src/main/resources/static/karaokee-openapi.json
@@ -761,7 +761,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Voting round with candidates sorted by vote count",
+            "description": "Voting round with candidates and their current vote counts (playlist order preserved)",
             "content": {
               "application/json": {
                 "schema": {
@@ -1203,7 +1203,7 @@
           },
           "candidates": {
             "type": "array",
-            "description": "Sorted descending by currentVoteCount",
+            "description": "Candidates with current vote counts, in playlist order",
             "items": {
               "$ref": "#/components/schemas/SongGetDTO"
             }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -6,6 +6,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.SessionWebSocketPublisher;
+import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.entity.Song;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,9 @@ class SessionServiceTest {
   
     @Mock
     private SessionWebSocketPublisher sessionWebSocketPublisher;
+
+    @Mock
+    private SongWebSocketPublisher songWebSocketPublisher;
 
     @InjectMocks
     private SessionService sessionService;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -5,7 +5,6 @@ import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
-import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.websocket.SessionWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.entity.Song;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +23,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyList;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
 
@@ -36,9 +34,6 @@ class SessionServiceTest {
 
     @Mock
     private UserRepository userRepository;
-
-    @Mock
-    private SongWebSocketPublisher songWebSocketPublisher;
 
     @Mock
     private SongService songService;
@@ -183,8 +178,22 @@ class SessionServiceTest {
                 () -> sessionService.joinSession(10L, "000000", 2L));
 
         assertEquals(400, ex.getStatusCode().value());
+        assert ex.getReason() != null;
         assertTrue(ex.getReason().toLowerCase().contains("invalid game pin"));
         // Must not proceed to user lookup or save when PIN is wrong
+        verify(userRepository, never()).findById(any());
+        verify(sessionRepository, never()).save(any());
+    }
+
+    @Test
+    void joinSession_endedSession_throwsNotFound() {
+        session.setStatus(SessionStatus.ENDED);
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> sessionService.joinSession(10L, "482910", 2L));
+
+        assertEquals(404, ex.getStatusCode().value());
         verify(userRepository, never()).findById(any());
         verify(sessionRepository, never()).save(any());
     }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -442,7 +443,7 @@ class SongServiceTest {
 
         when(sessionService.getSessionById(5L)).thenReturn(session);
 
-        songService.broadcastVotingRoundSongWinner(5L, winner);
+        songService.broadcastVotingRoundSongWinner(5L, winner, Collections.emptyMap());
 
         verify(songWebSocketPublisher).broadcastCurrentSong(eq(5L), argThat(dto -> dto != null && "Winner Song".equals(dto.getTitle())));
         verify(songWebSocketPublisher).broadcastQueue(eq(5L), argThat(list -> list.size() == 1));

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -338,7 +338,7 @@ class VotingServiceTest {
         when(sessionService.getSessionById(10L)).thenReturn(session);
         votingService.createVotingRound(10L);
 
-        verify(songService, times(1)).broadcastVotingRoundSongWinner(eq(10L), eq(candidateSong));
+        verify(songService, times(1)).broadcastVotingRoundSongWinner(eq(10L), eq(candidateSong), any());
         verify(votingRoundRepository, never()).save(any());
         verify(votingWebSocketPublisher, never()).broadcastVotingRound(anyLong(), any());
         verify(taskScheduler, never()).schedule(any(Runnable.class), any(Instant.class));
@@ -385,7 +385,7 @@ class VotingServiceTest {
         assertEquals(VotingStatus.CLOSED, votingRound.getStatus());
         verify(votingRoundRepository, times(1)).save(votingRound);
 
-        verify(songService, times(1)).broadcastVotingRoundSongWinner(eq(10L), eq(candidateSong));
+        verify(songService, times(1)).broadcastVotingRoundSongWinner(eq(10L), eq(candidateSong), any());
     }
 
     @Test
@@ -396,7 +396,7 @@ class VotingServiceTest {
         votingService.finishVotingRoundAndPlayNextSong(10L, 50L);
 
         verify(votingRoundRepository, never()).save(any());
-        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any());
+        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any(), any());
     }
 
     @Test
@@ -505,7 +505,7 @@ class VotingServiceTest {
 
         votingService.createVotingRound(10L);
 
-        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any());
+        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any(), any());
         verify(votingRoundRepository, never()).save(any());
         verify(votingWebSocketPublisher, never()).broadcastVotingRound(anyLong(), any());
         verify(taskScheduler, never()).schedule(any(Runnable.class), any(Instant.class));
@@ -520,7 +520,7 @@ class VotingServiceTest {
 
         votingService.createVotingRound(10L);
 
-        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any());
+        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any(), any());
         verify(votingRoundRepository, never()).save(any());
     }
 


### PR DESCRIPTION
1) remove Song sorting during voting phase
2) Had to broadcast the current votecount with the winning song for frontend after voting
3) Participant can not join anymore an ended session

---

This pull request updates the handling of broadcasting voting round song winners by allowing the vote counts to be passed and used throughout the service and test layers. It also adds a check to prevent users from joining sessions that have already ended. The changes ensure that the correct vote data is available for broadcasting and that the session state is properly validated.

**Broadcasting Voting Round Song Winner:**
* Updated the `broadcastVotingRoundSongWinner` method in `SongService` to accept and use a `voteCounts` map, ensuring that vote data is available when broadcasting the winning song. All related service and test method calls have been updated to include this new parameter. [[1]](diffhunk://#diff-843b2a0ff682f99ed650f11c6640b7f4a5784bd1cd3a768ada305d671ea368bcL227-R230) [[2]](diffhunk://#diff-ecefdadb4cdb0fbbac3ac38624b1db1e52f9bb8b1a8de67b115cd95d44c0b680L142-R142) [[3]](diffhunk://#diff-ecefdadb4cdb0fbbac3ac38624b1db1e52f9bb8b1a8de67b115cd95d44c0b680L218-R218) [[4]](diffhunk://#diff-ee464a2a6999603cf8dac2a66de11f2a43a4d021beb95c2a9f81c725783fa249L445-R446) [[5]](diffhunk://#diff-0d1787a10f9632640ea88c11ed8c6dc6628a34e776df7c8f890cdcc28ea138eaL341-R341) [[6]](diffhunk://#diff-0d1787a10f9632640ea88c11ed8c6dc6628a34e776df7c8f890cdcc28ea138eaL388-R388) [[7]](diffhunk://#diff-0d1787a10f9632640ea88c11ed8c6dc6628a34e776df7c8f890cdcc28ea138eaL399-R399) [[8]](diffhunk://#diff-0d1787a10f9632640ea88c11ed8c6dc6628a34e776df7c8f890cdcc28ea138eaL508-R508) [[9]](diffhunk://#diff-0d1787a10f9632640ea88c11ed8c6dc6628a34e776df7c8f890cdcc28ea138eaL523-R523)

**Session Joining Validation:**
* Added a check in `SessionService` to throw an error if a user attempts to join a session that has already ended, improving session state validation.

**Code Cleanup:**
* Removed an unused import from `DTOMapper.java` for code cleanliness.
* Removed unnecessary sorting by vote count in `DTOMapper.sortedByVotes`, likely as part of refactoring how vote data is handled.
* Added missing import for `Collections` in `SongServiceTest` to support new method signatures.