### PR TITLE
Implement song tracking, promotion logic, and WebSocket updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ local.properties
 /.claude/
 /docs/
 /htmlReport/
+/inspection/

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ReactionMessageHandler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ReactionMessageHandler.java
@@ -52,7 +52,8 @@ public class ReactionMessageHandler {
         ReactionType reactionType;
         try {
             reactionType = ReactionType.fromValue(type);
-        } catch (IllegalArgumentException e) {
+        }
+        catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Unknown reaction type: " + type);
         }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
@@ -3,8 +3,8 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
+import ch.uzh.ifi.hase.soprafs26.service.SessionService;
 import ch.uzh.ifi.hase.soprafs26.service.SongService;
-import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,12 +17,12 @@ import java.util.List;
 public class SongsController implements SongsApi {
     private static final String TOKEN_HEADER = "token";
     private final SongService songService;
-    private final UserService userService;
+    private final SessionService sessionService;
     private final HttpServletRequest request;
 
-    SongsController(SongService songService, UserService userService, HttpServletRequest request) {
+    SongsController(SongService songService, SessionService sessionService, HttpServletRequest request) {
         this.songService = songService;
-        this.userService = userService;
+        this.sessionService = sessionService;
         this.request = request;
     }
 
@@ -75,7 +75,7 @@ public class SongsController implements SongsApi {
     @Override
     public ResponseEntity<Void> sessionsSessionIdSongsNextPost(Long sessionId) {
         String token = request.getHeader(TOKEN_HEADER);
-        userService.getUserByToken(token);
+        sessionService.verifyIsAdmin(sessionId, token);
         songService.nextSong(sessionId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 public class SongsController implements SongsApi {
@@ -57,11 +56,9 @@ public class SongsController implements SongsApi {
     // Returns 200 + SongGetDTO, 204 if nothing is playing, 404 if session not found
     @Override
     public ResponseEntity<SongGetDTO> sessionsSessionIdSongsCurrentGet(Long sessionId) {
-        Optional<SongGetDTO> current = songService.getCurrentSong(sessionId);
-        if (current.isEmpty()) {
-            return ResponseEntity.noContent().build();
-        }
-        return ResponseEntity.ok(current.get());
+        return songService.getCurrentSong(sessionId)
+                .<ResponseEntity<SongGetDTO>>map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
     }
 
     // POST /sessions/{sessionId}/songs/skip — Skip current song, admin only (S7)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
@@ -76,6 +76,10 @@ public class SongsController implements SongsApi {
     // Marks the current song as performed, broadcasts next currentSong + queue
     @Override
     public ResponseEntity<Void> sessionsSessionIdSongsNextPost(Long sessionId) {
+        String token = request.getHeader(TOKEN_HEADER);
+        if (token == null || token.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+        }
         songService.nextSong(sessionId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SongsController.java
@@ -4,6 +4,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.service.SongService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,10 +18,12 @@ import java.util.Optional;
 public class SongsController implements SongsApi {
     private static final String TOKEN_HEADER = "token";
     private final SongService songService;
+    private final UserService userService;
     private final HttpServletRequest request;
 
-    SongsController(SongService songService, HttpServletRequest request) {
+    SongsController(SongService songService, UserService userService, HttpServletRequest request) {
         this.songService = songService;
+        this.userService = userService;
         this.request = request;
     }
 
@@ -75,9 +78,7 @@ public class SongsController implements SongsApi {
     @Override
     public ResponseEntity<Void> sessionsSessionIdSongsNextPost(Long sessionId) {
         String token = request.getHeader(TOKEN_HEADER);
-        if (token == null || token.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
-        }
+        userService.getUserByToken(token);
         songService.nextSong(sessionId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/VotingController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/VotingController.java
@@ -33,8 +33,7 @@ public class VotingController implements VotingApi {
     // Returns 200 + list of VotingRoundGetDTO
     @Override
     public ResponseEntity<List<VotingRoundGetDTO>> sessionsSessionIdVotingRoundsGet(Long sessionId) {
-        // TODO: delegate to votingService.getRounds(sessionId)
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+        return ResponseEntity.ok(votingService.getRoundsForSession(sessionId));
     }
 
     // GET /sessions/{sessionId}/votingRounds/{roundId} — Get a specific voting round (S14)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Session.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Session.java
@@ -112,7 +112,6 @@ public class Session {
 
     public void removeSong(Song song) {
         playlist.remove(song);
-        //song.setSession(null);
     }
 
     public void addToPendingInitialSong(User user) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Session.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Session.java
@@ -112,7 +112,7 @@ public class Session {
 
     public void removeSong(Song song) {
         playlist.remove(song);
-        song.setSession(null);
+        //song.setSession(null);
     }
 
     public void addToPendingInitialSong(User user) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Song.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Song.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 @Setter
 @Getter
@@ -55,6 +56,6 @@ public class Song {
     // to mark the song as performed
     public void markPerformed() {
         this.performed = true;
-        this.playedAt = LocalDateTime.now();
+        this.playedAt = LocalDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Song.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Song.java
@@ -3,6 +3,7 @@ package ch.uzh.ifi.hase.soprafs26.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import java.time.LocalDateTime;
 
 @Setter
 @Getter
@@ -39,6 +40,9 @@ public class Song {
     @Column(nullable = false)
     private Boolean performed = false;
 
+    @Column
+    private LocalDateTime playedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "session_id", nullable = false)
     private Session session;
@@ -50,5 +54,6 @@ public class Song {
     // to mark the song as performed
     public void markPerformed() {
         this.performed = true;
+        this.playedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Song.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Song.java
@@ -3,6 +3,7 @@ package ch.uzh.ifi.hase.soprafs26.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+
 import java.time.LocalDateTime;
 
 @Setter

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/VotingRound.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/VotingRound.java
@@ -33,7 +33,7 @@ public class VotingRound {
     @Column(nullable = false)
     private LocalDateTime startsAt;
 
-    @Column(nullable = true)
+    @Column
     private LocalDateTime endsAt;
 
     @ManyToMany(fetch = FetchType.LAZY)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/VotingRound.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/VotingRound.java
@@ -43,6 +43,7 @@ public class VotingRound {
             inverseJoinColumns = @JoinColumn(name = "song_id")
     )
     @OnDelete(action = OnDeleteAction.CASCADE)
+    @OrderBy("id ASC")
     private List<Song> candidates = new ArrayList<>();
 
     @OneToMany(mappedBy = "votingRound", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/SongRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/SongRepository.java
@@ -6,7 +6,4 @@ import org.springframework.stereotype.Repository;
 
 @Repository("songRepository")
 public interface SongRepository extends JpaRepository<Song, Long> {
-    Song findBySpotifyId(String spotifyId);
-
-    Song findByTitle(String title);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
@@ -4,6 +4,7 @@ import ch.uzh.ifi.hase.soprafs26.constant.VotingStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.entity.VotingRound;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -17,4 +18,8 @@ public interface VotingRoundRepository extends JpaRepository<VotingRound, Long> 
     @Query("SELECT DISTINCT vr FROM VotingRound vr LEFT JOIN FETCH vr.candidates WHERE vr.id = :id")
     Optional<VotingRound> findByIdWithCandidates(@Param("id") Long id);
     List<VotingRound> findBySessionOrderByStartsAtAsc(Session session);
+
+    @Modifying
+    @Query(value = "DELETE FROM voting_round_candidates WHERE song_id = :songId", nativeQuery = true)
+    void deleteCandidatesBySongId(@Param("songId") Long songId);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
@@ -17,7 +17,8 @@ public interface VotingRoundRepository extends JpaRepository<VotingRound, Long> 
     List<VotingRound> findBySessionAndStatus(Session session, VotingStatus status);
     @Query("SELECT DISTINCT vr FROM VotingRound vr LEFT JOIN FETCH vr.candidates WHERE vr.id = :id")
     Optional<VotingRound> findByIdWithCandidates(@Param("id") Long id);
-    List<VotingRound> findBySessionOrderByStartsAtAsc(Session session);
+    @Query("SELECT DISTINCT vr FROM VotingRound vr LEFT JOIN FETCH vr.candidates WHERE vr.session = :session ORDER BY vr.startsAt ASC")
+    List<VotingRound> findBySessionWithCandidatesOrderByStartsAtAsc(@Param("session") Session session);
 
     @Modifying
     @Query(value = "DELETE FROM voting_round_candidates WHERE song_id = :songId", nativeQuery = true)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
@@ -15,8 +15,10 @@ import java.util.Optional;
 @Repository("votingRoundRepository")
 public interface VotingRoundRepository extends JpaRepository<VotingRound, Long> {
     List<VotingRound> findBySessionAndStatus(Session session, VotingStatus status);
+
     @Query("SELECT DISTINCT vr FROM VotingRound vr LEFT JOIN FETCH vr.candidates WHERE vr.id = :id")
     Optional<VotingRound> findByIdWithCandidates(@Param("id") Long id);
+
     @Query("SELECT DISTINCT vr FROM VotingRound vr LEFT JOIN FETCH vr.candidates WHERE vr.session = :session ORDER BY vr.startsAt ASC")
     List<VotingRound> findBySessionWithCandidatesOrderByStartsAtAsc(@Param("session") Session session);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/VotingRoundRepository.java
@@ -16,4 +16,5 @@ public interface VotingRoundRepository extends JpaRepository<VotingRound, Long> 
     List<VotingRound> findBySessionAndStatus(Session session, VotingStatus status);
     @Query("SELECT vr FROM VotingRound vr LEFT JOIN FETCH vr.candidates WHERE vr.id = :id")
     Optional<VotingRound> findByIdWithCandidates(@Param("id") Long id);
+    List<VotingRound> findBySessionOrderByStartsAtAsc(Session session);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JoinSessionDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/JoinSessionDTO.java
@@ -67,10 +67,9 @@ public class JoinSessionDTO {
 
     @Override
     public String toString() {
-        String sb = "class JoinSessionDTO {\n" +
+        return "class JoinSessionDTO {\n" +
                 "    gamePin: " + toIndentedString(gamePin) + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ReactionPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ReactionPostDTO.java
@@ -70,10 +70,9 @@ public class ReactionPostDTO {
 
     @Override
     public String toString() {
-        String sb = "class ReactionPostDTO {\n" +
+        return "class ReactionPostDTO {\n" +
                 "    type: " + toIndentedString(type) + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
@@ -266,7 +266,7 @@ public class SessionGetDTO {
 
     @Override
     public String toString() {
-        String sb = "class SessionGetDTO {\n" +
+        return "class SessionGetDTO {\n" +
                 "    id: " + toIndentedString(id) + "\n" +
                 "    name: " + toIndentedString(name) + "\n" +
                 "    description: " + toIndentedString(description) + "\n" +
@@ -277,7 +277,6 @@ public class SessionGetDTO {
                 "    participants: " + toIndentedString(participants) + "\n" +
                 "    requiresSongSelection: " + toIndentedString(requiresSongSelection) + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionPostDTO.java
@@ -91,11 +91,10 @@ public class SessionPostDTO {
 
     @Override
     public String toString() {
-        String sb = "class SessionPostDTO {\n" +
+        return "class SessionPostDTO {\n" +
                 "    name: " + toIndentedString(name) + "\n" +
                 "    description: " + toIndentedString(description) + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionPutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionPutDTO.java
@@ -70,10 +70,9 @@ public class SessionPutDTO {
 
     @Override
     public String toString() {
-        String sb = "class SessionPutDTO {\n" +
+        return "class SessionPutDTO {\n" +
                 "    status: " + toIndentedString(status) + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongGetDTO.java
@@ -296,7 +296,7 @@ public class SongGetDTO {
 
     @Override
     public String toString() {
-        String sb = "class SongGetDTO {\n" +
+        return "class SongGetDTO {\n" +
                 "    id: " + toIndentedString(id) + "\n" +
                 "    spotifyId: " + toIndentedString(spotifyId) + "\n" +
                 "    title: " + toIndentedString(title) + "\n" +
@@ -310,7 +310,6 @@ public class SongGetDTO {
                 "    performed: " + toIndentedString(performed) + "\n" +
                 "    addedBy: " + toIndentedString(addedBy) + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongPostDTO.java
@@ -168,7 +168,7 @@ public class SongPostDTO {
 
     @Override
     public String toString() {
-        String sb = "class SongPostDTO {\n" +
+        return "class SongPostDTO {\n" +
                 "    spotifyId: " + toIndentedString(spotifyId) + "\n" +
                 "    title: " + toIndentedString(title) + "\n" +
                 "    artist: " + toIndentedString(artist) + "\n" +
@@ -176,7 +176,6 @@ public class SongPostDTO {
                 "    albumName: " + toIndentedString(albumName) + "\n" +
                 "    durationMs: " + toIndentedString(durationMs) + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongSearchResultDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SongSearchResultDTO.java
@@ -194,7 +194,7 @@ public class SongSearchResultDTO {
 
     @Override
     public String toString() {
-        String sb = "class SongSearchResultDTO {\n" +
+        return "class SongSearchResultDTO {\n" +
                 "    spotifyId: " + toIndentedString(spotifyId) + "\n" +
                 "    title: " + toIndentedString(title) + "\n" +
                 "    artist: " + toIndentedString(artist) + "\n" +
@@ -204,7 +204,6 @@ public class SongSearchResultDTO {
                 "    durationSeconds: " + toIndentedString(durationSeconds) + "\n" +
                 "    lyricsAvailable: " + toIndentedString(lyricsAvailable) + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPostDTO.java
@@ -92,11 +92,10 @@ public class UserPostDTO {
 
     @Override
     public String toString() {
-        String sb = "class UserPostDTO {\n" +
+        return "class UserPostDTO {\n" +
                 "    username: " + toIndentedString(username) + "\n" +
                 "    password: " + "*" + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserPutDTO.java
@@ -79,11 +79,10 @@ public class UserPutDTO {
 
     @Override
     public String toString() {
-        String sb = "class UserPutDTO {\n" +
+        return "class UserPutDTO {\n" +
                 "    newPassword: " + "*" + "\n" +
                 "    oldPassword: " + "*" + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/VotePostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/VotePostDTO.java
@@ -67,10 +67,9 @@ public class VotePostDTO {
 
     @Override
     public String toString() {
-        String sb = "class VotePostDTO {\n" +
+        return "class VotePostDTO {\n" +
                 "    songId: " + toIndentedString(songId) + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/VotingRoundGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/VotingRoundGetDTO.java
@@ -192,7 +192,7 @@ public class VotingRoundGetDTO {
 
     @Override
     public String toString() {
-        String sb = "class VotingRoundGetDTO {\n" +
+        return "class VotingRoundGetDTO {\n" +
                 "    id: " + toIndentedString(id) + "\n" +
                 "    roundNumber: " + toIndentedString(roundNumber) + "\n" +
                 "    status: " + toIndentedString(status) + "\n" +
@@ -200,7 +200,6 @@ public class VotingRoundGetDTO {
                 "    endsAt: " + toIndentedString(endsAt) + "\n" +
                 "    candidates: " + toIndentedString(candidates) + "\n" +
                 "}";
-        return sb;
     }
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -64,9 +64,9 @@ public interface DTOMapper {
     @Mapping(source = "token", target = "token")
     UserTokenDTO convertEntityToUserTokenDTO(User user);
 
-    @Mapping(target = "status",      source = "round.status")
-    @Mapping(target = "startedAt",   source = "round.startsAt")
-    @Mapping(target = "endsAt",      source = "round.endsAt")
+    @Mapping(target = "status", source = "round.status")
+    @Mapping(target = "startedAt", source = "round.startsAt")
+    @Mapping(target = "endsAt", source = "round.endsAt")
     @Mapping(target = "candidates", source = "candidates", qualifiedByName = "candidatesWithVoteCounts")
     @Mapping(target = "roundNumber", ignore = true)
     VotingRoundGetDTO toVotingRoundGetDTO(VotingRound round, @Context Map<Long, Long> counts);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -48,6 +48,7 @@ public interface DTOMapper {
     @Mapping(source = "admin", target = "admin")
     @Mapping(source = "participants", target = "participants")
     @Mapping(source = "createdAt", target = "createdAt")
+    @Mapping(target = "requiresSongSelection", ignore = true)
     SessionGetDTO convertEntityToSessionGetDTO(Session session);
 
     default OffsetDateTime map(LocalDateTime localDateTime) {
@@ -66,15 +67,16 @@ public interface DTOMapper {
     @Mapping(target = "status",      source = "round.status")
     @Mapping(target = "startedAt",   source = "round.startsAt")
     @Mapping(target = "endsAt",      source = "round.endsAt")
-    @Mapping(target = "candidates", source = "candidates", qualifiedByName = "sortedByVotes")
+    @Mapping(target = "candidates", source = "candidates", qualifiedByName = "candidatesWithVoteCounts")
+    @Mapping(target = "roundNumber", ignore = true)
     VotingRoundGetDTO toVotingRoundGetDTO(VotingRound round, @Context Map<Long, Long> counts);
 
     @Mapping(target = "currentVoteCount", expression = "java(counts.getOrDefault(song.getId(), 0L).intValue())")
     @Mapping(target = "durationSeconds", expression = "java(song.getDurationMs() != null ? song.getDurationMs() / 1000 : null)")
     SongGetDTO toSongGetDTO(Song song, @Context Map<Long, Long> counts);
 
-    @Named("sortedByVotes")
-    default List<SongGetDTO> sortedByVotes(List<Song> songs, @Context Map<Long, Long> counts) {
+    @Named("candidatesWithVoteCounts")
+    default List<SongGetDTO> candidatesWithVoteCounts(List<Song> songs, @Context Map<Long, Long> counts) {
         return songs.stream()
                 .map(s -> toSongGetDTO(s, counts))
                 .toList();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -14,7 +14,6 @@ import org.mapstruct.factory.Mappers;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -78,7 +77,6 @@ public interface DTOMapper {
     default List<SongGetDTO> sortedByVotes(List<Song> songs, @Context Map<Long, Long> counts) {
         return songs.stream()
                 .map(s -> toSongGetDTO(s, counts))
-                .sorted(Comparator.comparingInt(SongGetDTO::getCurrentVoteCount).reversed())
                 .toList();
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -147,12 +147,10 @@ public class SessionService {
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, USER_NOT_FOUND));
 
-        boolean isNewParticipant = !session.getParticipants().contains(user);
-
         // Set.add() is a no-op when user is already present → idempotent
         session.addParticipant(user);
 
-        if (isNewParticipant) {
+        if (session.getStatus() == SessionStatus.CREATED && !hasContributedSong(session, user)) {
             session.addToPendingInitialSong(user);
         }
 
@@ -177,6 +175,11 @@ public class SessionService {
         return saved;
     }
 
+    private boolean hasContributedSong(Session session, User user) {
+        return session.getPlaylist().stream()
+                .anyMatch(s -> s.getAddedBy() != null
+                        && s.getAddedBy().getId().equals(user.getId()));
+    }
 
     /**
      * Remove a user from a session's participant list (soft-leave).

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -126,6 +126,9 @@ public class SessionService {
         if (current == SessionStatus.CREATED && newStatus == SessionStatus.ACTIVE) {
             songService.promoteNextSong(sessionId, session);
         }
+        // requiresSongSelection is a per-user field; it is intentionally null here
+        // since this is a broadcast to all subscribers. Clients needing this flag
+        // should read it from the REST response (GET /sessions/{id}/participants).
         sessionWebSocketPublisher.broadcastSessionStatus(sessionId,
                 DTOMapper.INSTANCE.convertEntityToSessionGetDTO(savedSession));
         return savedSession;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -123,7 +123,7 @@ public class SessionService {
 
         session.setStatus(newStatus);
         Session savedSession = sessionRepository.save(session);
-        if (current == SessionStatus.CREATED) {
+        if (current == SessionStatus.CREATED && newStatus == SessionStatus.ACTIVE) {
             songService.promoteNextSong(sessionId, session);
         }
         sessionWebSocketPublisher.broadcastSessionStatus(sessionId,
@@ -281,16 +281,16 @@ public class SessionService {
         return session.isPendingInitialSong(user);
     }
 
-//    public void markInitialSongAdded(Long sessionId, Long userId) {
-//        Session session = getSessionById(sessionId);
-//        User user = userRepository.findById(userId)
-//                .orElseThrow(() -> new ResponseStatusException(
-//                        HttpStatus.NOT_FOUND, USER_NOT_FOUND));
-//        session.removeFromPendingInitialSong(user);
-//        sessionRepository.save(session);
-//        log.debug("User {} fulfilled initial song requirement for session {}",
-//                userId, sessionId);
-//    }
+    public void markInitialSongAdded(Long sessionId, Long userId) {
+        Session session = getSessionById(sessionId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, USER_NOT_FOUND));
+        session.removeFromPendingInitialSong(user);
+        sessionRepository.save(session);
+        log.debug("User {} fulfilled initial song requirement for session {}",
+                userId, sessionId);
+    }
 
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -123,7 +123,7 @@ public class SessionService {
 
         session.setStatus(newStatus);
         Session savedSession = sessionRepository.save(session);
-        if (current == SessionStatus.CREATED && newStatus == SessionStatus.ACTIVE) {
+        if (current == SessionStatus.CREATED) {
             songService.promoteNextSong(sessionId, session);
         }
         sessionWebSocketPublisher.broadcastSessionStatus(sessionId,
@@ -159,7 +159,7 @@ public class SessionService {
         }
 
         if (session.getStatus() == SessionStatus.ENDED) {
-            throw new ResponseStatusException(HttpStatus.GONE, "Session has already ended");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Session has already ended");
         }
 
         User user = userRepository.findById(userId)
@@ -281,16 +281,16 @@ public class SessionService {
         return session.isPendingInitialSong(user);
     }
 
-    public void markInitialSongAdded(Long sessionId, Long userId) {
-        Session session = getSessionById(sessionId);
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, USER_NOT_FOUND));
-        session.removeFromPendingInitialSong(user);
-        sessionRepository.save(session);
-        log.debug("User {} fulfilled initial song requirement for session {}",
-                userId, sessionId);
-    }
+//    public void markInitialSongAdded(Long sessionId, Long userId) {
+//        Session session = getSessionById(sessionId);
+//        User user = userRepository.findById(userId)
+//                .orElseThrow(() -> new ResponseStatusException(
+//                        HttpStatus.NOT_FOUND, USER_NOT_FOUND));
+//        session.removeFromPendingInitialSong(user);
+//        sessionRepository.save(session);
+//        log.debug("User {} fulfilled initial song requirement for session {}",
+//                userId, sessionId);
+//    }
 
 
     /**

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -6,7 +6,9 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.websocket.SessionWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,8 +18,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
-import ch.uzh.ifi.hase.soprafs26.websocket.SessionWebSocketPublisher;
 
 import java.util.*;
 
@@ -190,7 +190,7 @@ public class SessionService {
                             DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes));
                     songWebSocketPublisher.broadcastLyrics(sessionId, s.getLyrics());
                 });
-        
+
         List<UserGetDTO> participantDTOs = saved.getParticipants().stream()
                 .map(DTOMapper.INSTANCE::convertEntityToUserGetDTO)
                 .toList();
@@ -235,7 +235,7 @@ public class SessionService {
                 .map(DTOMapper.INSTANCE::convertEntityToUserGetDTO)
                 .toList();
         sessionWebSocketPublisher.broadcastParticipants(sessionId, participantDTOs);
-        
+
         log.debug("User {} left session {}", userId, sessionId);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -158,6 +158,10 @@ public class SessionService {
                     HttpStatus.BAD_REQUEST, "Invalid game pin");
         }
 
+        if (session.getStatus() == SessionStatus.ENDED) {
+            throw new ResponseStatusException(HttpStatus.GONE, "Session has already ended");
+        }
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, USER_NOT_FOUND));

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -172,8 +172,12 @@ public class SessionService {
         // Set.add() is a no-op when user is already present → idempotent
         session.addParticipant(user);
 
-        if (session.getStatus() == SessionStatus.CREATED && !hasContributedSong(session, user)) {
-            session.addToPendingInitialSong(user);
+        if (session.getStatus() == SessionStatus.CREATED || session.getStatus() == SessionStatus.ACTIVE) {
+            if (hasContributedSong(session, user)) {
+                session.removeFromPendingInitialSong(user);
+            } else {
+                session.addToPendingInitialSong(user);
+            }
         }
 
         Session saved = sessionRepository.save(session);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -177,6 +177,7 @@ public class SessionService {
 
         Map<Long, Long> emptyVotes = new HashMap<>();
         List<SongGetDTO> queue = saved.getPlaylist().stream()
+                .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
                 .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
                 .toList();
         songWebSocketPublisher.broadcastQueue(sessionId, queue);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -15,8 +15,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
+import ch.uzh.ifi.hase.soprafs26.websocket.SessionWebSocketPublisher;
 
 import java.util.*;
+
 
 @Service
 @Transactional
@@ -30,15 +33,17 @@ public class SessionService {
     private final SessionRepository sessionRepository;
     private final UserRepository userRepository;
     private final SongWebSocketPublisher songWebSocketPublisher;
+    private final SessionWebSocketPublisher sessionWebSocketPublisher;
     private final UserService userService;
 
     @Autowired
     public SessionService(SessionRepository sessionRepository,
                           UserRepository userRepository,
-                          SongWebSocketPublisher songWebSocketPublisher, UserService userService) {
+                          SongWebSocketPublisher songWebSocketPublisher, SessionWebSocketPublisher sessionWebSocketPublisher, UserService userService) {
         this.sessionRepository = sessionRepository;
         this.userRepository = userRepository;
         this.songWebSocketPublisher = songWebSocketPublisher;
+        this.sessionWebSocketPublisher = sessionWebSocketPublisher;
         this.userService = userService;
     }
 
@@ -113,7 +118,10 @@ public class SessionService {
         }
 
         session.setStatus(newStatus);
-        return sessionRepository.save(session);
+        Session saved = sessionRepository.save(session);
+        sessionWebSocketPublisher.broadcastSessionStatus(sessionId,
+                DTOMapper.INSTANCE.convertEntityToSessionGetDTO(saved));
+        return saved;
     }
 
 
@@ -172,6 +180,11 @@ public class SessionService {
                             DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes));
                     songWebSocketPublisher.broadcastLyrics(sessionId, s.getLyrics());
                 });
+        
+        List<UserGetDTO> participantDTOs = saved.getParticipants().stream()
+                .map(DTOMapper.INSTANCE::convertEntityToUserGetDTO)
+                .toList();
+        sessionWebSocketPublisher.broadcastParticipants(sessionId, participantDTOs);
 
         log.debug("User {} joined session {}", userId, sessionId);
         return saved;
@@ -201,7 +214,13 @@ public class SessionService {
                         HttpStatus.NOT_FOUND, "Session or participant not found"));
 
         session.removeParticipant(user);
-        sessionRepository.save(session);
+        Session saved = sessionRepository.save(session);
+
+        List<UserGetDTO> participantDTOs = saved.getParticipants().stream()
+                .map(DTOMapper.INSTANCE::convertEntityToUserGetDTO)
+                .toList();
+        sessionWebSocketPublisher.broadcastParticipants(sessionId, participantDTOs);
+        
         log.debug("User {} left session {}", userId, sessionId);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -11,6 +11,7 @@ import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,15 +32,18 @@ public class SessionService {
     private final UserRepository userRepository;
     private final SongWebSocketPublisher songWebSocketPublisher;
     private final UserService userService;
+    private final SongService songService;
 
     @Autowired
     public SessionService(SessionRepository sessionRepository,
                           UserRepository userRepository,
-                          SongWebSocketPublisher songWebSocketPublisher, UserService userService) {
+                          SongWebSocketPublisher songWebSocketPublisher, UserService userService,
+                          @Lazy SongService songService) {
         this.sessionRepository = sessionRepository;
         this.userRepository = userRepository;
         this.songWebSocketPublisher = songWebSocketPublisher;
         this.userService = userService;
+        this.songService = songService;
     }
 
     public void verifyIsAdmin(Long sessionId, String token) {
@@ -113,7 +117,11 @@ public class SessionService {
         }
 
         session.setStatus(newStatus);
-        return sessionRepository.save(session);
+        Session savedSession = sessionRepository.save(session);
+        if (current == SessionStatus.CREATED && newStatus == SessionStatus.ACTIVE) {
+            songService.promoteNextSong(sessionId, session);
+        }
+        return savedSession;
     }
 
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -284,7 +284,7 @@ public class SongService {
                 .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
                 .findFirst()
                 .ifPresent(current -> {
-                    current.setPerformed(true);
+                    current.markPerformed();
                     songRepository.save(current);
                 });
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -170,6 +170,7 @@ public class SongService {
                 .map(s -> s.getId().equals(songId))
                 .orElse(false);
 
+        votingService.removeSongFromCandidates(songToDelete.getId());
         session.removeSong(songToDelete);
         songRepository.delete(songToDelete);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -157,17 +157,25 @@ public class SongService {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Song not found in this session");
         }
 
+        boolean isCurrentSong = session.getPlaylist().stream()
+                .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
+                .findFirst()
+                .map(s -> s.getId().equals(songId))
+                .orElse(false);
+
         session.removeSong(songToDelete);
         songRepository.delete(songToDelete);
 
-        Map<Long, Long> emptyVotes = Collections.emptyMap();
-        List<SongGetDTO> remainingQueue = session.getPlaylist().stream()
-                .filter(song -> !Boolean.TRUE.equals(song.getPerformed()))
-                .map(song -> DTOMapper.INSTANCE.toSongGetDTO(song, emptyVotes))
-                .toList();
-
-        // TODO: Next ticket will refactor nextSong() function where as the method extracted will be used here
-        songWebSocketPublisher.broadcastQueue(sessionId, remainingQueue);
+        if (isCurrentSong) {
+            promoteNextSong(sessionId, session);
+        } else {
+            Map<Long, Long> emptyVotes = Collections.emptyMap();
+            List<SongGetDTO> remainingQueue = session.getPlaylist().stream()
+                    .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
+                    .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                    .toList();
+            songWebSocketPublisher.broadcastQueue(sessionId, remainingQueue);
+        }
     }
 
     @Transactional

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -24,6 +24,8 @@ import java.util.stream.IntStream;
 @Service
 public class SongService {
 
+    private static final Map<Long, Long> EMPTY_VOTES = Collections.emptyMap();
+
     private final SpotifyService spotifyService;
     private final LyricsService lyricsService;
     private final SongRepository songRepository;
@@ -95,23 +97,21 @@ public class SongService {
 
         session.addSong(song); // update in-memory list for broadcast
 
-        Map<Long, Long> emptyVotes = Collections.emptyMap();
-
         // Broadcast updated queue (no votes yet → empty counts map)
         List<SongGetDTO> queue = session.getPlaylist().stream()
                 .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
-                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, EMPTY_VOTES))
                 .toList();
         songWebSocketPublisher.broadcastQueue(sessionId, queue);
 
         // If this is the only unplayed song, the queue was empty before — promote it as currentSong
         if (queue.size() == 1) {
-            SongGetDTO songDTO = DTOMapper.INSTANCE.toSongGetDTO(song, emptyVotes);
+            SongGetDTO songDTO = DTOMapper.INSTANCE.toSongGetDTO(song, EMPTY_VOTES);
             songWebSocketPublisher.broadcastCurrentSong(sessionId, songDTO);
             songWebSocketPublisher.broadcastLyrics(sessionId, song.getLyrics());
         }
 
-        return DTOMapper.INSTANCE.toSongGetDTO(song, emptyVotes);
+        return DTOMapper.INSTANCE.toSongGetDTO(song, EMPTY_VOTES);
     }
 
     /**
@@ -122,10 +122,6 @@ public class SongService {
         return lyricsCache.getOrDefault(spotifyId, Optional.empty()).orElse(null);
     }
 
-    Map<String, Optional<String>> getLyricsCache() {
-        return Map.copyOf(lyricsCache);
-    }
-
     void cacheLyrics(String spotifyId, String lyrics) {
         lyricsCache.put(spotifyId, Optional.ofNullable(lyrics));
     }
@@ -133,22 +129,18 @@ public class SongService {
     @Transactional(readOnly = true)
     public Optional<SongGetDTO> getCurrentSong(Long sessionId) {
         Session session = sessionService.getSessionById(sessionId);
-        Map<Long, Long> emptyVotes = Collections.emptyMap();
-
         return session.getPlaylist().stream()
                 .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
                 .findFirst()
-                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes));
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, EMPTY_VOTES));
     }
 
     @Transactional(readOnly = true)
     public List<SongGetDTO> getQueue(Long sessionId) {
         Session session = sessionService.getSessionById(sessionId);
-        Map<Long, Long> emptyVotes = Collections.emptyMap();
-
         return session.getPlaylist().stream()
                 .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
-                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, EMPTY_VOTES))
                 .toList();
     }
 
@@ -176,11 +168,11 @@ public class SongService {
 
         if (isCurrentSong) {
             promoteNextSong(sessionId, session);
-        } else {
-            Map<Long, Long> emptyVotes = Collections.emptyMap();
+        }
+        else {
             List<SongGetDTO> remainingQueue = session.getPlaylist().stream()
                     .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
-                    .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, emptyVotes))
+                    .map(s -> DTOMapper.INSTANCE.toSongGetDTO(s, EMPTY_VOTES))
                     .toList();
             songWebSocketPublisher.broadcastQueue(sessionId, remainingQueue);
         }
@@ -203,20 +195,21 @@ public class SongService {
 
     @Transactional
     public void promoteNextSong(Long sessionId, Session session) {
-        Map<Long, Long> emptyVotes = Collections.emptyMap();
         List<Song> unplayedSongs = session.getPlaylist().stream()
                 .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
                 .toList();
 
         if (unplayedSongs.size() >= 2) {
             votingService.createVotingRound(sessionId);
-        } else if (unplayedSongs.size() == 1) {
+        }
+        else if (unplayedSongs.size() == 1) {
             Song lastSong = unplayedSongs.get(0);
-            SongGetDTO nextSongDTO = DTOMapper.INSTANCE.toSongGetDTO(lastSong, emptyVotes);
+            SongGetDTO nextSongDTO = DTOMapper.INSTANCE.toSongGetDTO(lastSong, EMPTY_VOTES);
             songWebSocketPublisher.broadcastCurrentSong(sessionId, nextSongDTO);
             songWebSocketPublisher.broadcastQueue(sessionId, List.of(nextSongDTO));
             songWebSocketPublisher.broadcastLyrics(sessionId, lastSong.getLyrics());
-        } else {
+        }
+        else {
             songWebSocketPublisher.broadcastCurrentSong(sessionId, null);
             songWebSocketPublisher.broadcastQueue(sessionId, Collections.emptyList());
             songWebSocketPublisher.broadcastLyrics(sessionId, null);
@@ -226,12 +219,12 @@ public class SongService {
     @Transactional(readOnly = true)
     public void broadcastVotingRoundSongWinner(Long sessionId, Song winner, Map<Long, Long> voteCounts) {
         Session session = sessionService.getSessionById(sessionId);
-        Map<Long, Long> emptyVotes = Collections.emptyMap();
+
         SongGetDTO nextSong = DTOMapper.INSTANCE.toSongGetDTO(winner, voteCounts);
 
         List<SongGetDTO> remainingQueue = session.getPlaylist().stream()
                 .filter(song -> !Boolean.TRUE.equals(song.getPerformed()))
-                .map(song -> DTOMapper.INSTANCE.toSongGetDTO(song, emptyVotes))
+                .map(song -> DTOMapper.INSTANCE.toSongGetDTO(song, EMPTY_VOTES))
                 .toList();
 
         songWebSocketPublisher.broadcastCurrentSong(sessionId, nextSong);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -193,6 +193,7 @@ public class SongService {
         promoteNextSong(sessionId, session);
     }
 
+    @Transactional
     public void promoteNextSong(Long sessionId, Session session) {
         Map<Long, Long> emptyVotes = Collections.emptyMap();
         List<Song> unplayedSongs = session.getPlaylist().stream()

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -104,6 +104,13 @@ public class SongService {
                 .toList();
         songWebSocketPublisher.broadcastQueue(sessionId, queue);
 
+        // If this is the only unplayed song, the queue was empty before — promote it as currentSong
+        if (queue.size() == 1) {
+            SongGetDTO songDTO = DTOMapper.INSTANCE.toSongGetDTO(song, emptyVotes);
+            songWebSocketPublisher.broadcastCurrentSong(sessionId, songDTO);
+            songWebSocketPublisher.broadcastLyrics(sessionId, song.getLyrics());
+        }
+
         return DTOMapper.INSTANCE.toSongGetDTO(song, emptyVotes);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -193,7 +193,7 @@ public class SongService {
         promoteNextSong(sessionId, session);
     }
 
-    private void promoteNextSong(Long sessionId, Session session) {
+    public void promoteNextSong(Long sessionId, Session session) {
         Map<Long, Long> emptyVotes = Collections.emptyMap();
         List<Song> unplayedSongs = session.getPlaylist().stream()
                 .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -173,7 +173,6 @@ public class SongService {
     @Transactional
     public void nextSong(Long sessionId) {
         Session session = sessionService.getSessionById(sessionId);
-        Map<Long, Long> emptyVotes = Collections.emptyMap();
 
         session.getPlaylist().stream()
                 .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
@@ -183,6 +182,11 @@ public class SongService {
                     songRepository.save(current);
                 });
 
+        promoteNextSong(sessionId, session);
+    }
+
+    private void promoteNextSong(Long sessionId, Session session) {
+        Map<Long, Long> emptyVotes = Collections.emptyMap();
         List<Song> unplayedSongs = session.getPlaylist().stream()
                 .filter(s -> !Boolean.TRUE.equals(s.getPerformed()))
                 .toList();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -224,10 +224,10 @@ public class SongService {
     }
 
     @Transactional(readOnly = true)
-    public void broadcastVotingRoundSongWinner(Long sessionId, Song winner) {
+    public void broadcastVotingRoundSongWinner(Long sessionId, Song winner, Map<Long, Long> voteCounts) {
         Session session = sessionService.getSessionById(sessionId);
         Map<Long, Long> emptyVotes = Collections.emptyMap();
-        SongGetDTO nextSong = DTOMapper.INSTANCE.toSongGetDTO(winner, emptyVotes);
+        SongGetDTO nextSong = DTOMapper.INSTANCE.toSongGetDTO(winner, voteCounts);
 
         List<SongGetDTO> remainingQueue = session.getPlaylist().stream()
                 .filter(song -> !Boolean.TRUE.equals(song.getPerformed()))

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SpotifyTrack.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SpotifyTrack.java
@@ -1,4 +1,5 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
-public record SpotifyTrack(String spotifyId, String title, String artist, String albumName, String albumArt, int durationMs) {
+public record SpotifyTrack(String spotifyId, String title, String artist, String albumName, String albumArt,
+                           int durationMs) {
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
@@ -221,7 +221,7 @@ public class VotingService {
     @Transactional(readOnly = true)
     public List<VotingRoundGetDTO> getRoundsForSession(Long sessionId) {
         Session session = sessionService.getSessionById(sessionId);
-        List<VotingRound> rounds = votingRoundRepository.findBySessionOrderByStartsAtAsc(session);
+        List<VotingRound> rounds = votingRoundRepository.findBySessionWithCandidatesOrderByStartsAtAsc(session);
         return rounds.stream()
                 .map(r -> {
                     Map<Long, Long> counts = getVoteCounts(r);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
@@ -139,7 +139,7 @@ public class VotingService {
             return;
         }
         if (playlist.size() == 1) {
-            songService.broadcastVotingRoundSongWinner(sessionId, playlist.get(0));
+            songService.broadcastVotingRoundSongWinner(sessionId, playlist.get(0), Collections.emptyMap());
             return;
         }
 
@@ -215,7 +215,7 @@ public class VotingService {
 
         Song votingRoundSongWinner = winnerCandidates.get(random.nextInt(winnerCandidates.size()));
         moveWinnerToFrontOfQueue(sessionId, votingRoundSongWinner);
-        songService.broadcastVotingRoundSongWinner(sessionId, votingRoundSongWinner);
+        songService.broadcastVotingRoundSongWinner(sessionId, votingRoundSongWinner, finalCounts);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
@@ -8,19 +8,18 @@ import ch.uzh.ifi.hase.soprafs26.repository.VotingRoundRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs26.websocket.VotingWebSocketPublisher;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.scheduling.TaskScheduler;
-import org.springframework.context.ApplicationContext;
-
-import java.time.ZoneOffset;
-import java.util.*;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -92,7 +91,8 @@ public class VotingService {
         vote.setVotedSong(song);
         try {
             voteRepository.saveAndFlush(vote);
-        } catch (DataIntegrityViolationException ex) {
+        }
+        catch (DataIntegrityViolationException ex) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Already voted");
         }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
@@ -215,4 +215,16 @@ public class VotingService {
         moveWinnerToFrontOfQueue(sessionId, votingRoundSongWinner);
         songService.broadcastVotingRoundSongWinner(sessionId, votingRoundSongWinner);
     }
+
+    @Transactional(readOnly = true)
+    public List<VotingRoundGetDTO> getRoundsForSession(Long sessionId) {
+        Session session = sessionService.getSessionById(sessionId);
+        List<VotingRound> rounds = votingRoundRepository.findBySessionOrderByStartsAtAsc(session);
+        return rounds.stream()
+                .map(r -> {
+                    Map<Long, Long> counts = getVoteCounts(r);
+                    return DTOMapper.INSTANCE.toVotingRoundGetDTO(r, counts);
+                })
+                .toList();
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
@@ -229,4 +229,9 @@ public class VotingService {
                 })
                 .toList();
     }
+
+    @Transactional
+    public void removeSongFromCandidates(Long songId) {
+        votingRoundRepository.deleteCandidatesBySongId(songId);
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/CurrentSongPayload.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/CurrentSongPayload.java
@@ -1,0 +1,22 @@
+package ch.uzh.ifi.hase.soprafs26.websocket;
+
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
+
+public class CurrentSongPayload {
+    private SongGetDTO song;
+
+    public CurrentSongPayload() {
+    }
+
+    public CurrentSongPayload(SongGetDTO song) {
+        this.song = song;
+    }
+
+    public SongGetDTO getSong() {
+        return song;
+    }
+
+    public void setSong(SongGetDTO sog) {
+        this.song = song;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/CurrentSongPayload.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/CurrentSongPayload.java
@@ -16,7 +16,7 @@ public class CurrentSongPayload {
         return song;
     }
 
-    public void setSong(SongGetDTO sog) {
+    public void setSong(SongGetDTO song) {
         this.song = song;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SessionWebSocketPublisherImpl.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SessionWebSocketPublisherImpl.java
@@ -1,0 +1,29 @@
+package ch.uzh.ifi.hase.soprafs26.websocket;
+
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class SessionWebSocketPublisherImpl implements SessionWebSocketPublisher {
+
+    private static final String TOPIC_PREFIX = "/topic/sessions/";
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public SessionWebSocketPublisherImpl(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    @Override
+    public void broadcastSessionStatus(Long sessionId, SessionGetDTO session) {
+        messagingTemplate.convertAndSend(TOPIC_PREFIX + sessionId + "/status", session);
+    }
+
+    @Override
+    public void broadcastParticipants(Long sessionId, List<UserGetDTO> participants) {
+        messagingTemplate.convertAndSend(TOPIC_PREFIX + sessionId + "/participants", participants);
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImpl.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImpl.java
@@ -24,7 +24,8 @@ public class SongWebSocketPublisherImpl implements SongWebSocketPublisher {
 
     @Override
     public void broadcastCurrentSong(Long sessionId, SongGetDTO currentSong) {
-        messagingTemplate.convertAndSend(TOPIC_PREFIX + sessionId + "/currentSong", currentSong);
+        messagingTemplate.convertAndSend(TOPIC_PREFIX + sessionId + "/currentSong",
+                new CurrentSongPayload(currentSong));
     }
 
     @Override

--- a/src/main/resources/karaokee-asyncapi.yaml
+++ b/src/main/resources/karaokee-asyncapi.yaml
@@ -86,6 +86,19 @@ channels:
       queue:
         $ref: '#/components/messages/QueueMessage'
 
+  /topic/sessions/{sessionId}/lyrics:
+    address: /topic/sessions/{sessionId}/lyrics
+    description: >
+      Broadcast when a new song becomes current. Contains the song's lyrics (null if unavailable).
+      Triggered by: POST /sessions/{id}/songs (first song added), POST /sessions/{id}/songs/next,
+      POST /sessions/{id}/songs/skip.
+    parameters:
+      sessionId:
+        $ref: '#/components/parameters/sessionId'
+    messages:
+      lyrics:
+        $ref: '#/components/messages/LyricsMessage'
+
   /topic/sessions/{sessionId}/participants:
     address: /topic/sessions/{sessionId}/participants
     description: >
@@ -132,6 +145,12 @@ operations:
     channel:
       $ref: '#/channels/~1topic~1sessions~1{sessionId}~1queue'
     summary: Client receives updated song queue
+
+  receiveLyrics:
+    action: receive
+    channel:
+      $ref: '#/channels/~1topic~1sessions~1{sessionId}~1lyrics'
+    summary: Client receives lyrics for the current song
 
   receiveParticipants:
     action: receive
@@ -181,6 +200,12 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/SongDTO'
+
+    LyricsMessage:
+      name: LyricsMessage
+      summary: Lyrics for the currently playing song
+      payload:
+        $ref: '#/components/schemas/LyricsPayload'
 
     ParticipantsMessage:
       name: ParticipantsMessage
@@ -293,9 +318,17 @@ components:
           format: date-time
         candidates:
           type: array
-          description: Sorted descending by currentVoteCount
+          description: Candidates with current vote counts, in playlist order
           items:
             $ref: '#/components/schemas/SongDTO'
+
+    LyricsPayload:
+      type: object
+      properties:
+        lyrics:
+          type: string
+          nullable: true
+          description: Full song lyrics, or null if not available
 
     ReactionDTO:
       type: object

--- a/src/main/resources/karaokee-asyncapi.yaml
+++ b/src/main/resources/karaokee-asyncapi.yaml
@@ -27,6 +27,8 @@ channels:
       Broadcast when the current song changes.
       Triggered by: admin skip (POST /sessions/{id}/songs/skip), natural song end,
       or marking song as played (PUT /sessions/{id}/songs/{songId}/played).
+      The payload is always a CurrentSongPayload object; `song` is null
+      when there is no current song (cleared / queue exhausted).
     parameters:
       sessionId:
         $ref: '#/components/parameters/sessionId'
@@ -152,7 +154,7 @@ components:
       name: CurrentSongMessage
       summary: Currently playing song with lyrics
       payload:
-        $ref: '#/components/schemas/SongDTO'
+        $ref: '#/components/schemas/CurrentSongPayload'
 
     VotingRoundMessage:
       name: VotingRoundMessage
@@ -227,6 +229,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/UserDTO'
+
+    CurrentSongPayload:
+      type: object
+      description: >
+        Wrapper for the current song. `song` is null when there is no
+        active song (e.g. session cleared / queue exhausted).
+      properties:
+        song:
+          allOf:
+            - $ref: '#/components/schemas/SongDTO'
+          nullable: true
+      required:
+        - song
 
     SongDTO:
       type: object

--- a/src/main/resources/static/karaokee-openapi.json
+++ b/src/main/resources/static/karaokee-openapi.json
@@ -761,7 +761,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Voting round with candidates sorted by vote count",
+            "description": "Voting round with candidates and their current vote counts (playlist order preserved)",
             "content": {
               "application/json": {
                 "schema": {
@@ -1203,7 +1203,7 @@
           },
           "candidates": {
             "type": "array",
-            "description": "Sorted descending by currentVoteCount",
+            "description": "Candidates with current vote counts, in playlist order",
             "items": {
               "$ref": "#/components/schemas/SongGetDTO"
             }

--- a/src/main/resources/static/karaokee-openapi.json
+++ b/src/main/resources/static/karaokee-openapi.json
@@ -1,403 +1,403 @@
 {
-  "openapi": "3.0.3",
-  "info": {
-    "title": "Karaokee API",
-    "description": "REST API for the Karaokee Session Tool – FS26 Group 22",
-    "version": "1.0.0"
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Karaokee API",
+    "description" : "REST API for the Karaokee Session Tool – FS26 Group 22",
+    "version" : "1.0.0"
   },
-  "servers": [
+  "servers" : [
     {
-      "url": "https://sopra-fs26-group-22-server.oa.r.appspot.com",
-      "description": "Production (Google Cloud)"
+      "url" : "https://sopra-fs26-group-22-server.oa.r.appspot.com",
+      "description" : "Production (Google Cloud)"
     },
     {
-      "url": "http://localhost:8080",
-      "description": "Local development"
+      "url" : "http://localhost:8080",
+      "description" : "Local development"
     }
   ],
-  "security": [
+  "security" : [
     {
-      "token": []
+      "token" : []
     }
   ],
-  "tags": [
+  "tags" : [
     {
-      "name": "Auth",
-      "description": "Registration and login"
+      "name" : "Auth",
+      "description" : "Registration and login"
     },
     {
-      "name": "Users",
-      "description": "User management"
+      "name" : "Users",
+      "description" : "User management"
     },
     {
-      "name": "Sessions",
-      "description": "Karaoke session lifecycle"
+      "name" : "Sessions",
+      "description" : "Karaoke session lifecycle"
     },
     {
-      "name": "Songs",
-      "description": "Song search and queue management"
+      "name" : "Songs",
+      "description" : "Song search and queue management"
     },
     {
-      "name": "Voting",
-      "description": "VotingRounds and Votes"
+      "name" : "Voting",
+      "description" : "VotingRounds and Votes"
     },
     {
-      "name": "Reactions",
-      "description": "Live emoji reactions"
+      "name" : "Reactions",
+      "description" : "Live emoji reactions"
     }
   ],
-  "paths": {
-    "/users": {
-      "post": {
-        "tags": [
+  "paths" : {
+    "/users" : {
+      "post" : {
+        "tags" : [
           "Auth"
         ],
-        "summary": "Register a new user (S1)",
-        "security": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserPostDTO"
+        "summary" : "Register a new user (S1)",
+        "security" : [],
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserPostDTO"
               }
             }
           }
         },
-        "responses": {
-          "201": {
-            "description": "User created; token returned",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserTokenDTO"
+        "responses" : {
+          "201" : {
+            "description" : "User created; token returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserTokenDTO"
                 }
               }
             }
           },
-          "409": {
-            "description": "Username already taken"
+          "409" : {
+            "description" : "Username already taken"
           }
         }
       }
     },
-    "/auth/login": {
-      "post": {
-        "tags": [
+    "/auth/login" : {
+      "post" : {
+        "tags" : [
           "Auth"
         ],
-        "summary": "Login with username and password",
-        "security": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserPostDTO"
+        "summary" : "Login with username and password",
+        "security" : [],
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserPostDTO"
               }
             }
           }
         },
-        "responses": {
-          "200": {
-            "description": "Login successful; token returned",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserTokenDTO"
+        "responses" : {
+          "200" : {
+            "description" : "Login successful; token returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserTokenDTO"
                 }
               }
             }
           },
-          "401": {
-            "description": "Invalid credentials"
+          "401" : {
+            "description" : "Invalid credentials"
           },
-          "404": {
-            "description": "User not found"
+          "404" : {
+            "description" : "User not found"
           }
         }
       }
     },
-    "/auth/logout": {
-      "post": {
-        "tags": [
+    "/auth/logout" : {
+      "post" : {
+        "tags" : [
           "Auth"
         ],
-        "summary": "Logout (invalidates token)",
-        "responses": {
-          "204": {
-            "description": "Logged out successfully"
+        "summary" : "Logout (invalidates token)",
+        "responses" : {
+          "204" : {
+            "description" : "Logged out successfully"
           },
-          "401": {
-            "description": "Unauthorized"
+          "401" : {
+            "description" : "Unauthorized"
           }
         }
       }
     },
-    "/users/{userId}": {
-      "put": {
-        "tags": [
+    "/users/{userId}" : {
+      "put" : {
+        "tags" : [
           "Users"
         ],
-        "summary": "Update user – e.g. change password (S2)",
-        "parameters": [
+        "summary" : "Update user – e.g. change password (S2)",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/userId"
+            "$ref" : "#/components/parameters/userId"
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserPutDTO"
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserPutDTO"
               }
             }
           }
         },
-        "responses": {
-          "204": {
-            "description": "Updated successfully"
+        "responses" : {
+          "204" : {
+            "description" : "Updated successfully"
           },
-          "400": {
-            "description": "Password mismatch or invalid input"
+          "400" : {
+            "description" : "Password mismatch or invalid input"
           },
-          "403": {
-            "description": "Forbidden – can only edit own profile"
+          "403" : {
+            "description" : "Forbidden – can only edit own profile"
           },
-          "404": {
-            "description": "User not found"
+          "404" : {
+            "description" : "User not found"
           }
         }
       }
     },
-    "/users/{userId}/sessions": {
-      "get": {
-        "tags": [
+    "/users/{userId}/sessions" : {
+      "get" : {
+        "tags" : [
           "Users"
         ],
-        "summary": "Get session history for a user (S13)",
-        "parameters": [
+        "summary" : "Get session history for a user (S13)",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/userId"
+            "$ref" : "#/components/parameters/userId"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "List of sessions created or joined by user",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SessionGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "List of sessions created or joined by user",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/SessionGetDTO"
                   }
                 }
               }
             }
           },
-          "404": {
-            "description": "User not found"
+          "404" : {
+            "description" : "User not found"
           }
         }
       }
     },
-    "/sessions": {
-      "post": {
-        "tags": [
+    "/sessions" : {
+      "post" : {
+        "tags" : [
           "Sessions"
         ],
-        "summary": "Create a new karaoke session (S3)",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SessionPostDTO"
+        "summary" : "Create a new karaoke session (S3)",
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SessionPostDTO"
               }
             }
           }
         },
-        "responses": {
-          "201": {
-            "description": "Session created; creator becomes admin",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionGetDTO"
+        "responses" : {
+          "201" : {
+            "description" : "Session created; creator becomes admin",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SessionGetDTO"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "401" : {
+            "description" : "Unauthorized"
           }
         }
       }
     },
-    "/sessions/pin/{gamePin}": {
-      "get": {
-        "tags": [
+    "/sessions/pin/{gamePin}" : {
+      "get" : {
+        "tags" : [
           "Sessions"
         ],
-        "summary": "Look up a session by its game pin",
-        "parameters": [
+        "summary" : "Look up a session by its game pin",
+        "parameters" : [
           {
-            "name": "gamePin",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+            "name" : "gamePin",
+            "in" : "path",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
             }
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Session found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "Session found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SessionGetDTO"
                 }
               }
             }
           },
-          "404": {
-            "description": "No session with that pin"
+          "404" : {
+            "description" : "No session with that pin"
           }
         }
       }
     },
-    "/sessions/{sessionId}": {
-      "get": {
-        "tags": [
+    "/sessions/{sessionId}" : {
+      "get" : {
+        "tags" : [
           "Sessions"
         ],
-        "summary": "Get session details",
-        "parameters": [
+        "summary" : "Get session details",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Session details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "Session details",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SessionGetDTO"
                 }
               }
             }
           },
-          "404": {
-            "description": "Session not found"
+          "404" : {
+            "description" : "Session not found"
           }
         }
       },
-      "put": {
-        "tags": [
+      "put" : {
+        "tags" : [
           "Sessions"
         ],
-        "summary": "Update session status – start / pause / end (S4)",
-        "description": "Admin-only. Allowed transitions:\nCREATED → ACTIVE, ACTIVE → PAUSED, PAUSED → ACTIVE, ACTIVE|PAUSED → ENDED\n",
-        "parameters": [
+        "summary" : "Update session status – start / pause / end (S4)",
+        "description" : "Admin-only. Allowed transitions:\nCREATED → ACTIVE, ACTIVE → PAUSED, PAUSED → ACTIVE, ACTIVE|PAUSED → ENDED\n",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SessionPutDTO"
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SessionPutDTO"
               }
             }
           }
         },
-        "responses": {
-          "200": {
-            "description": "Session updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "Session updated",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SessionGetDTO"
                 }
               }
             }
           },
-          "400": {
-            "description": "Invalid status transition"
+          "400" : {
+            "description" : "Invalid status transition"
           },
-          "403": {
-            "description": "Only the admin can change session status"
+          "403" : {
+            "description" : "Only the admin can change session status"
           },
-          "404": {
-            "description": "Session not found"
+          "404" : {
+            "description" : "Session not found"
           }
         }
       }
     },
-    "/sessions/{sessionId}/participants": {
-      "post": {
-        "tags": [
+    "/sessions/{sessionId}/participants" : {
+      "post" : {
+        "tags" : [
           "Sessions"
         ],
-        "summary": "Join a session via game pin (S5)",
-        "parameters": [
+        "summary" : "Join a session via game pin (S5)",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/JoinSessionDTO"
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/JoinSessionDTO"
               }
             }
           }
         },
-        "responses": {
-          "200": {
-            "description": "Joined successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "Joined successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SessionGetDTO"
                 }
               }
             }
           },
-          "400": {
-            "description": "Invalid game pin"
+          "400" : {
+            "description" : "Invalid game pin"
           },
-          "404": {
-            "description": "Session not found"
+          "404" : {
+            "description" : "Session not found"
           }
         }
       },
-      "get": {
-        "tags": [
+      "get" : {
+        "tags" : [
           "Sessions"
         ],
-        "summary": "List participants of a session",
-        "parameters": [
+        "summary" : "List participants of a session",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "List of participants",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UserGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "List of participants",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/UserGetDTO"
                   }
                 }
               }
@@ -406,121 +406,121 @@
         }
       }
     },
-    "/sessions/{sessionId}/participants/{userId}": {
-      "delete": {
-        "tags": [
+    "/sessions/{sessionId}/participants/{userId}" : {
+      "delete" : {
+        "tags" : [
           "Sessions"
         ],
-        "summary": "Leave a session – unassigns user from it (S5)",
-        "description": "Soft-leave: the user is removed from the active participant list but the\nsession record is preserved (e.g. for session history). The session itself\nis not deleted. Triggers a WebSocket broadcast on /topic/sessions/{sessionId}/participants.\n",
-        "parameters": [
+        "summary" : "Leave a session – unassigns user from it (S5)",
+        "description" : "Soft-leave: the user is removed from the active participant list but the\nsession record is preserved (e.g. for session history). The session itself\nis not deleted. Triggers a WebSocket broadcast on /topic/sessions/{sessionId}/participants.\n",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           },
           {
-            "$ref": "#/components/parameters/userId"
+            "$ref" : "#/components/parameters/userId"
           }
         ],
-        "responses": {
-          "204": {
-            "description": "User unassigned from session successfully"
+        "responses" : {
+          "204" : {
+            "description" : "User unassigned from session successfully"
           },
-          "404": {
-            "description": "Session or participant not found"
+          "404" : {
+            "description" : "Session or participant not found"
           }
         }
       }
     },
-    "/sessions/{sessionId}/review": {
-      "get": {
-        "tags": [
+    "/sessions/{sessionId}/review" : {
+      "get" : {
+        "tags" : [
           "Sessions"
         ],
-        "summary": "Get post-session review of performed songs (S15)",
-        "parameters": [
+        "summary" : "Get post-session review of performed songs (S15)",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "List of performed songs",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SongGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "List of performed songs",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/SongGetDTO"
                   }
                 }
               }
             }
           },
-          "403": {
-            "description": "Session not ended yet"
+          "403" : {
+            "description" : "Session not ended yet"
           },
-          "404": {
-            "description": "Session not found"
+          "404" : {
+            "description" : "Session not found"
           }
         }
       }
     },
-    "/songs/search": {
-      "get": {
-        "tags": [
+    "/songs/search" : {
+      "get" : {
+        "tags" : [
           "Songs"
         ],
-        "summary": "Search songs by title or artist via Spotify Web API (S11)",
-        "parameters": [
+        "summary" : "Search songs by title or artist via Spotify Web API (S11)",
+        "parameters" : [
           {
-            "name": "query",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
+            "name" : "query",
+            "in" : "query",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
             }
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Search results",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SongSearchResultDTO"
+        "responses" : {
+          "200" : {
+            "description" : "Search results",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/SongSearchResultDTO"
                   }
                 }
               }
             }
           },
-          "400": {
-            "description": "Missing or empty query"
+          "400" : {
+            "description" : "Missing or empty query"
           }
         }
       }
     },
-    "/sessions/{sessionId}/songs": {
-      "get": {
-        "tags": [
+    "/sessions/{sessionId}/songs" : {
+      "get" : {
+        "tags" : [
           "Songs"
         ],
-        "summary": "Get the ordered song queue of a session",
-        "parameters": [
+        "summary" : "Get the ordered song queue of a session",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Ordered song queue",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SongGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "Ordered song queue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/SongGetDTO"
                   }
                 }
               }
@@ -528,215 +528,215 @@
           }
         }
       },
-      "post": {
-        "tags": [
+      "post" : {
+        "tags" : [
           "Songs"
         ],
-        "summary": "Add a song to the session queue (S6, S10)",
-        "parameters": [
+        "summary" : "Add a song to the session queue (S6, S10)",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SongPostDTO"
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SongPostDTO"
               }
             }
           }
         },
-        "responses": {
-          "201": {
-            "description": "Song added to queue",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SongGetDTO"
+        "responses" : {
+          "201" : {
+            "description" : "Song added to queue",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SongGetDTO"
                 }
               }
             }
           },
-          "404": {
-            "description": "Session not found"
+          "404" : {
+            "description" : "Session not found"
           },
-          "422": {
-            "description": "Lyrics not available for this song"
+          "422" : {
+            "description" : "Lyrics not available for this song"
           }
         }
       }
     },
-    "/sessions/{sessionId}/songs/current": {
-      "get": {
-        "tags": [
+    "/sessions/{sessionId}/songs/current" : {
+      "get" : {
+        "tags" : [
           "Songs"
         ],
-        "summary": "Get the currently playing song with lyrics (S8)",
-        "parameters": [
+        "summary" : "Get the currently playing song with lyrics (S8)",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Current song with lyrics",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SongGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "Current song with lyrics",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SongGetDTO"
                 }
               }
             }
           },
-          "204": {
-            "description": "No song currently playing"
+          "204" : {
+            "description" : "No song currently playing"
           },
-          "404": {
-            "description": "Session not found"
+          "404" : {
+            "description" : "Session not found"
           }
         }
       }
     },
-    "/sessions/{sessionId}/songs/skip": {
-      "post": {
-        "tags": [
+    "/sessions/{sessionId}/songs/skip" : {
+      "post" : {
+        "tags" : [
           "Songs"
         ],
-        "summary": "Skip the current song – admin only (S7)",
-        "description": "Advances the queue to the next song without waiting for the current one to finish.\nTriggers two WebSocket broadcasts:\n- /topic/sessions/{sessionId}/currentSong with the new current song\n- /topic/sessions/{sessionId}/votingRound when a new voting round starts automatically\n",
-        "parameters": [
+        "summary" : "Skip the current song – admin only (S7)",
+        "description" : "Advances the queue to the next song without waiting for the current one to finish.\nTriggers two WebSocket broadcasts:\n- /topic/sessions/{sessionId}/currentSong with the new current song\n- /topic/sessions/{sessionId}/votingRound when a new voting round starts automatically\n",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Skipped; next song returned",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SongGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "Skipped; next song returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SongGetDTO"
                 }
               }
             }
           },
-          "403": {
-            "description": "Only admin can skip"
+          "403" : {
+            "description" : "Only admin can skip"
           },
-          "404": {
-            "description": "Session not found"
+          "404" : {
+            "description" : "Session not found"
           }
         }
       }
     },
-    "/sessions/{sessionId}/songs/next": {
-      "post": {
-        "tags": [
+    "/sessions/{sessionId}/songs/next" : {
+      "post" : {
+        "tags" : [
           "Songs"
         ],
-        "summary": "Advance to the next song after the current one finishes",
-        "description": "Marks the current song as performed and broadcasts the next currentSong and updated queue.\nTriggers two WebSocket broadcasts:\n- /topic/sessions/{sessionId}/currentSong\n- /topic/sessions/{sessionId}/queue",
-        "parameters": [
+        "summary" : "Advance to the next song after the current one finishes",
+        "description" : "Marks the current song as performed and broadcasts the next currentSong and updated queue.\nTriggers two WebSocket broadcasts:\n- /topic/sessions/{sessionId}/currentSong\n- /topic/sessions/{sessionId}/queue",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "responses": {
-          "204": {
-            "description": "Advanced to next song"
+        "responses" : {
+          "204" : {
+            "description" : "Advanced to next song"
           },
-          "404": {
-            "description": "Session not found"
+          "404" : {
+            "description" : "Session not found"
           }
         },
-        "security": [
+        "security" : [
           {
-            "token": []
+            "token" : []
           }
         ]
       }
     },
-    "/sessions/{sessionId}/songs/{songId}": {
-      "delete": {
-        "tags": [
+    "/sessions/{sessionId}/songs/{songId}" : {
+      "delete" : {
+        "tags" : [
           "Songs"
         ],
-        "summary": "Remove a song from the queue – admin only (S7)",
-        "parameters": [
+        "summary" : "Remove a song from the queue – admin only (S7)",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           },
           {
-            "$ref": "#/components/parameters/songId"
+            "$ref" : "#/components/parameters/songId"
           }
         ],
-        "responses": {
-          "204": {
-            "description": "Song removed"
+        "responses" : {
+          "204" : {
+            "description" : "Song removed"
           },
-          "401": {
-            "description": "Invalid or missing token"
+          "401" : {
+            "description" : "Invalid or missing token"
           },
-          "403": {
-            "description": "Only admin can remove songs"
+          "403" : {
+            "description" : "Only admin can remove songs"
           },
-          "404": {
-            "description": "Song or session not found"
+          "404" : {
+            "description" : "Song or session not found"
           }
         }
       }
     },
-    "/sessions/{sessionId}/songs/{songId}/played": {
-      "put": {
-        "tags": [
+    "/sessions/{sessionId}/songs/{songId}/played" : {
+      "put" : {
+        "tags" : [
           "Songs"
         ],
-        "summary": "Mark a song as played – admin only (no-op, use POST /songs/next instead)",
-        "description": "No-op stub. Song advancement is handled by POST /sessions/{sessionId}/songs/next.",
-        "parameters": [
+        "summary" : "Mark a song as played – admin only (no-op, use POST /songs/next instead)",
+        "description" : "No-op stub. Song advancement is handled by POST /sessions/{sessionId}/songs/next.",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           },
           {
-            "$ref": "#/components/parameters/songId"
+            "$ref" : "#/components/parameters/songId"
           }
         ],
-        "responses": {
-          "204": {
-            "description": "No-op; song advancement is handled by POST /songs/next"
+        "responses" : {
+          "204" : {
+            "description" : "No-op; song advancement is handled by POST /songs/next"
           },
-          "403": {
-            "description": "Only admin can mark songs as played"
+          "403" : {
+            "description" : "Only admin can mark songs as played"
           },
-          "404": {
-            "description": "Song or session not found"
+          "404" : {
+            "description" : "Song or session not found"
           }
         }
       }
     },
-    "/sessions/{sessionId}/votingRounds": {
-      "get": {
-        "tags": [
+    "/sessions/{sessionId}/votingRounds" : {
+      "get" : {
+        "tags" : [
           "Voting"
         ],
-        "summary": "List all voting rounds of a session",
-        "description": "VotingRounds are started automatically by the server when a song ends.",
-        "parameters": [
+        "summary" : "List all voting rounds of a session",
+        "description" : "VotingRounds are started automatically by the server when a song ends.",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "List of voting rounds",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/VotingRoundGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "List of voting rounds",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/VotingRoundGetDTO"
                   }
                 }
               }
@@ -745,177 +745,177 @@
         }
       }
     },
-    "/sessions/{sessionId}/votingRounds/{roundId}": {
-      "get": {
-        "tags": [
+    "/sessions/{sessionId}/votingRounds/{roundId}" : {
+      "get" : {
+        "tags" : [
           "Voting"
         ],
-        "summary": "Get a specific voting round – leaderboard (S14)",
-        "parameters": [
+        "summary" : "Get a specific voting round – leaderboard (S14)",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           },
           {
-            "$ref": "#/components/parameters/roundId"
+            "$ref" : "#/components/parameters/roundId"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Voting round with candidates and their current vote counts (playlist order preserved)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VotingRoundGetDTO"
+        "responses" : {
+          "200" : {
+            "description" : "Voting round with candidates and their current vote counts (playlist order preserved)",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VotingRoundGetDTO"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not found"
+          "404" : {
+            "description" : "Not found"
           }
         }
       }
     },
-    "/sessions/{sessionId}/votingRounds/{roundId}/votes": {
-      "post": {
-        "tags": [
+    "/sessions/{sessionId}/votingRounds/{roundId}/votes" : {
+      "post" : {
+        "tags" : [
           "Voting"
         ],
-        "summary": "Cast a vote for a candidate song (S12)",
-        "parameters": [
+        "summary" : "Cast a vote for a candidate song (S12)",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           },
           {
-            "$ref": "#/components/parameters/roundId"
+            "$ref" : "#/components/parameters/roundId"
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VotePostDTO"
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VotePostDTO"
               }
             }
           }
         },
-        "responses": {
-          "201": {
-            "description": "Vote cast"
+        "responses" : {
+          "201" : {
+            "description" : "Vote cast"
           },
-          "400": {
-            "description": "Song is not a candidate in this round"
+          "400" : {
+            "description" : "Song is not a candidate in this round"
           },
-          "409": {
-            "description": "User has already voted in this round"
+          "409" : {
+            "description" : "User has already voted in this round"
           },
-          "410": {
-            "description": "Voting round is CLOSED"
+          "410" : {
+            "description" : "Voting round is CLOSED"
           },
-          "403": {
-            "description": "User is not a session participant"
+          "403" : {
+            "description" : "User is not a session participant"
           },
-          "404": {
-            "description": "Voting round or song not found"
+          "404" : {
+            "description" : "Voting round or song not found"
           }
         }
       }
     },
-    "/sessions/{sessionId}/reactions": {
-      "post": {
-        "tags": [
+    "/sessions/{sessionId}/reactions" : {
+      "post" : {
+        "tags" : [
           "Reactions"
         ],
-        "summary": "Send a live reaction during a performance (S9)",
-        "parameters": [
+        "summary" : "Send a live reaction during a performance (S9)",
+        "parameters" : [
           {
-            "$ref": "#/components/parameters/sessionId"
+            "$ref" : "#/components/parameters/sessionId"
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ReactionPostDTO"
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ReactionPostDTO"
               }
             }
           }
         },
-        "responses": {
-          "201": {
-            "description": "Reaction sent"
+        "responses" : {
+          "201" : {
+            "description" : "Reaction sent"
           },
-          "400": {
-            "description": "No song currently performing"
+          "400" : {
+            "description" : "No song currently performing"
           },
-          "404": {
-            "description": "Session not found"
+          "404" : {
+            "description" : "Session not found"
           }
         }
       }
     }
   },
-  "components": {
-    "parameters": {
-      "userId": {
-        "name": "userId",
-        "in": "path",
-        "required": true,
-        "schema": {
-          "type": "integer",
-          "format": "int64"
+  "components" : {
+    "parameters" : {
+      "userId" : {
+        "name" : "userId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "integer",
+          "format" : "int64"
         }
       },
-      "sessionId": {
-        "name": "sessionId",
-        "in": "path",
-        "required": true,
-        "schema": {
-          "type": "integer",
-          "format": "int64"
+      "sessionId" : {
+        "name" : "sessionId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "integer",
+          "format" : "int64"
         }
       },
-      "songId": {
-        "name": "songId",
-        "in": "path",
-        "required": true,
-        "schema": {
-          "type": "integer",
-          "format": "int64"
+      "songId" : {
+        "name" : "songId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "integer",
+          "format" : "int64"
         }
       },
-      "roundId": {
-        "name": "roundId",
-        "in": "path",
-        "required": true,
-        "schema": {
-          "type": "integer",
-          "format": "int64"
+      "roundId" : {
+        "name" : "roundId",
+        "in" : "path",
+        "required" : true,
+        "schema" : {
+          "type" : "integer",
+          "format" : "int64"
         }
       }
     },
-    "schemas": {
-      "SessionStatus": {
-        "type": "string",
-        "enum": [
+    "schemas" : {
+      "SessionStatus" : {
+        "type" : "string",
+        "enum" : [
           "CREATED",
           "ACTIVE",
           "PAUSED",
           "ENDED"
         ]
       },
-      "VotingStatus": {
-        "type": "string",
-        "enum": [
+      "VotingStatus" : {
+        "type" : "string",
+        "enum" : [
           "OPEN",
           "CLOSED"
         ]
       },
-      "ReactionType": {
-        "type": "string",
-        "enum": [
+      "ReactionType" : {
+        "type" : "string",
+        "enum" : [
           "FIRE",
           "HEART",
           "CLAP",
@@ -923,322 +923,322 @@
           "SKULL"
         ]
       },
-      "UserPostDTO": {
-        "type": "object",
-        "required": [
+      "UserPostDTO" : {
+        "type" : "object",
+        "required" : [
           "username",
           "password"
         ],
-        "properties": {
-          "username": {
-            "type": "string",
-            "example": "dominic42"
+        "properties" : {
+          "username" : {
+            "type" : "string",
+            "example" : "dominic42"
           },
-          "password": {
-            "type": "string",
-            "format": "password"
+          "password" : {
+            "type" : "string",
+            "format" : "password"
           }
         }
       },
-      "UserPutDTO": {
-        "type": "object",
-        "properties": {
-          "newPassword": {
-            "type": "string",
-            "format": "password"
+      "UserPutDTO" : {
+        "type" : "object",
+        "properties" : {
+          "newPassword" : {
+            "type" : "string",
+            "format" : "password"
           },
-          "oldPassword": {
-            "type": "string",
-            "format": "password"
+          "oldPassword" : {
+            "type" : "string",
+            "format" : "password"
           }
         }
       },
-      "UserGetDTO": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
+      "UserGetDTO" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "username": {
-            "type": "string"
+          "username" : {
+            "type" : "string"
           },
-          "createdAt": {
-            "type": "string",
-            "format": "date"
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date"
           }
         }
       },
-      "UserTokenDTO": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
+      "UserTokenDTO" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "username": {
-            "type": "string"
+          "username" : {
+            "type" : "string"
           },
-          "token": {
-            "type": "string",
-            "format": "uuid"
+          "token" : {
+            "type" : "string",
+            "format" : "uuid"
           },
-          "createdAt": {
-            "type": "string",
-            "format": "date"
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date"
           }
         }
       },
-      "SessionPostDTO": {
-        "type": "object",
-        "required": [
+      "SessionPostDTO" : {
+        "type" : "object",
+        "required" : [
           "name"
         ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "example": "Friday Night Karaoke"
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "example" : "Friday Night Karaoke"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           }
         }
       },
-      "SessionPutDTO": {
-        "type": "object",
-        "required": [
+      "SessionPutDTO" : {
+        "type" : "object",
+        "required" : [
           "status"
         ],
-        "properties": {
-          "status": {
-            "$ref": "#/components/schemas/SessionStatus"
+        "properties" : {
+          "status" : {
+            "$ref" : "#/components/schemas/SessionStatus"
           }
         }
       },
-      "SessionGetDTO": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
+      "SessionGetDTO" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "name": {
-            "type": "string"
+          "name" : {
+            "type" : "string"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "gamePin": {
-            "type": "string",
-            "example": "482910"
+          "gamePin" : {
+            "type" : "string",
+            "example" : "482910"
           },
-          "status": {
-            "$ref": "#/components/schemas/SessionStatus"
+          "status" : {
+            "$ref" : "#/components/schemas/SessionStatus"
           },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "admin": {
-            "$ref": "#/components/schemas/UserGetDTO"
+          "admin" : {
+            "$ref" : "#/components/schemas/UserGetDTO"
           },
-          "participants": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/UserGetDTO"
+          "participants" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/UserGetDTO"
             }
           },
-          "requiresSongSelection": {
-            "type": "boolean",
-            "description": "True only in the join endpoint response — indicates the caller still needs to add their initial song before interacting with the session. Null in all other context."
+          "requiresSongSelection" : {
+            "type" : "boolean",
+            "description" : "True only in the join endpoint response — indicates the caller still needs to add their initial song before interacting with the session. Null in all other context."
           }
         }
       },
-      "JoinSessionDTO": {
-        "type": "object",
-        "required": [
+      "JoinSessionDTO" : {
+        "type" : "object",
+        "required" : [
           "gamePin"
         ],
-        "properties": {
-          "gamePin": {
-            "type": "string",
-            "example": "482910"
+        "properties" : {
+          "gamePin" : {
+            "type" : "string",
+            "example" : "482910"
           }
         }
       },
-      "SongPostDTO": {
-        "type": "object",
-        "required": [
+      "SongPostDTO" : {
+        "type" : "object",
+        "required" : [
           "spotifyId",
           "title",
           "artist",
           "durationMs"
         ],
-        "properties": {
-          "spotifyId": {
-            "type": "string"
+        "properties" : {
+          "spotifyId" : {
+            "type" : "string"
           },
-          "title": {
-            "type": "string",
-            "example": "Dancing Queen"
+          "title" : {
+            "type" : "string",
+            "example" : "Dancing Queen"
           },
-          "artist": {
-            "type": "string",
-            "example": "ABBA"
+          "artist" : {
+            "type" : "string",
+            "example" : "ABBA"
           },
-          "albumArt": {
-            "type": "string",
-            "nullable": true
+          "albumArt" : {
+            "type" : "string",
+            "nullable" : true
           },
-          "albumName": {
-            "type": "string",
-            "nullable": true
+          "albumName" : {
+            "type" : "string",
+            "nullable" : true
           },
-          "durationMs": {
-            "type": "integer",
-            "example": 354000
+          "durationMs" : {
+            "type" : "integer",
+            "example" : 354000
           }
         }
       },
-      "SongGetDTO": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
+      "SongGetDTO" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "spotifyId": {
-            "type": "string",
-            "nullable": true
+          "spotifyId" : {
+            "type" : "string",
+            "nullable" : true
           },
-          "title": {
-            "type": "string"
+          "title" : {
+            "type" : "string"
           },
-          "artist": {
-            "type": "string"
+          "artist" : {
+            "type" : "string"
           },
-          "albumArt": {
-            "type": "string",
-            "nullable": true
+          "albumArt" : {
+            "type" : "string",
+            "nullable" : true
           },
-          "albumName": {
-            "type": "string",
-            "nullable": true
+          "albumName" : {
+            "type" : "string",
+            "nullable" : true
           },
-          "durationMs": {
-            "type": "integer"
+          "durationMs" : {
+            "type" : "integer"
           },
-          "durationSeconds": {
-            "type": "integer",
-            "nullable": true
+          "durationSeconds" : {
+            "type" : "integer",
+            "nullable" : true
           },
-          "lyrics": {
-            "type": "string",
-            "nullable": true
+          "lyrics" : {
+            "type" : "string",
+            "nullable" : true
           },
-          "currentVoteCount": {
-            "type": "integer"
+          "currentVoteCount" : {
+            "type" : "integer"
           },
-          "performed": {
-            "type": "boolean"
+          "performed" : {
+            "type" : "boolean"
           },
-          "addedBy": {
-            "$ref": "#/components/schemas/UserGetDTO"
+          "addedBy" : {
+            "$ref" : "#/components/schemas/UserGetDTO"
           }
         }
       },
-      "SongSearchResultDTO": {
-        "type": "object",
-        "properties": {
-          "spotifyId": {
-            "type": "string",
-            "nullable": true
+      "SongSearchResultDTO" : {
+        "type" : "object",
+        "properties" : {
+          "spotifyId" : {
+            "type" : "string",
+            "nullable" : true
           },
-          "title": {
-            "type": "string"
+          "title" : {
+            "type" : "string"
           },
-          "artist": {
-            "type": "string"
+          "artist" : {
+            "type" : "string"
           },
-          "albumArt": {
-            "type": "string",
-            "nullable": true
+          "albumArt" : {
+            "type" : "string",
+            "nullable" : true
           },
-          "albumName": {
-            "type": "string",
-            "nullable": true
+          "albumName" : {
+            "type" : "string",
+            "nullable" : true
           },
-          "durationMs": {
-            "type": "integer"
+          "durationMs" : {
+            "type" : "integer"
           },
-          "durationSeconds": {
-            "type": "integer",
-            "nullable": true
+          "durationSeconds" : {
+            "type" : "integer",
+            "nullable" : true
           },
-          "lyricsAvailable": {
-            "type": "boolean"
+          "lyricsAvailable" : {
+            "type" : "boolean"
           }
         }
       },
-      "VotingRoundGetDTO": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
+      "VotingRoundGetDTO" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "roundNumber": {
-            "type": "integer"
+          "roundNumber" : {
+            "type" : "integer"
           },
-          "status": {
-            "$ref": "#/components/schemas/VotingStatus"
+          "status" : {
+            "$ref" : "#/components/schemas/VotingStatus"
           },
-          "startedAt": {
-            "type": "string",
-            "format": "date-time"
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "endsAt": {
-            "type": "string",
-            "format": "date-time"
+          "endsAt" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "candidates": {
-            "type": "array",
-            "description": "Candidates with current vote counts, in playlist order",
-            "items": {
-              "$ref": "#/components/schemas/SongGetDTO"
+          "candidates" : {
+            "type" : "array",
+            "description" : "Candidates with current vote counts, in playlist order",
+            "items" : {
+              "$ref" : "#/components/schemas/SongGetDTO"
             }
           }
         }
       },
-      "VotePostDTO": {
-        "type": "object",
-        "required": [
+      "VotePostDTO" : {
+        "type" : "object",
+        "required" : [
           "songId"
         ],
-        "properties": {
-          "songId": {
-            "type": "integer",
-            "format": "int64"
+        "properties" : {
+          "songId" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         }
       },
-      "ReactionPostDTO": {
-        "type": "object",
-        "required": [
+      "ReactionPostDTO" : {
+        "type" : "object",
+        "required" : [
           "type"
         ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/ReactionType"
+        "properties" : {
+          "type" : {
+            "$ref" : "#/components/schemas/ReactionType"
           }
         }
       }
     },
-    "securitySchemes": {
-      "token": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "token"
+    "securitySchemes" : {
+      "token" : {
+        "type" : "apiKey",
+        "in" : "header",
+        "name" : "token"
       }
     }
   }

--- a/src/main/resources/static/karaokee-openapi.json
+++ b/src/main/resources/static/karaokee-openapi.json
@@ -604,7 +604,7 @@
         "tags" : [
           "Songs"
         ],
-        "summary" : "Skip the current song – admin only (S7)",
+        "summary" : "Skip the current song – admin only (S7) – not yet implemented",
         "description" : "Advances the queue to the next song without waiting for the current one to finish.\nTriggers two WebSocket broadcasts:\n- /topic/sessions/{sessionId}/currentSong with the new current song\n- /topic/sessions/{sessionId}/votingRound when a new voting round starts automatically\n",
         "parameters" : [
           {
@@ -627,6 +627,9 @@
           },
           "404" : {
             "description" : "Session not found"
+          },
+          "501" : {
+            "description" : "Not yet implemented"
           }
         }
       }
@@ -706,12 +709,6 @@
         "responses" : {
           "204" : {
             "description" : "No-op; song advancement is handled by POST /songs/next"
-          },
-          "403" : {
-            "description" : "Only admin can mark songs as played"
-          },
-          "404" : {
-            "description" : "Song or session not found"
           }
         }
       }
@@ -827,7 +824,7 @@
         "tags" : [
           "Reactions"
         ],
-        "summary" : "Send a live reaction during a performance (S9)",
+        "summary" : "Send a live reaction during a performance (S9) – not yet implemented",
         "parameters" : [
           {
             "$ref" : "#/components/parameters/sessionId"
@@ -852,6 +849,9 @@
           },
           "404" : {
             "description" : "Session not found"
+          },
+          "501" : {
+            "description" : "Not yet implemented"
           }
         }
       }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/ApiDefaultMethodsTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/ApiDefaultMethodsTest.java
@@ -5,7 +5,6 @@ import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.context.request.NativeWebRequest;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/ReactionMessageHandlerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/ReactionMessageHandlerTest.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionsControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionsControllerTest.java
@@ -3,7 +3,9 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.JoinSessionDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionPutDTO;
 import ch.uzh.ifi.hase.soprafs26.service.SessionService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,11 +20,6 @@ import org.springframework.web.server.ResponseStatusException;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
-import ch.uzh.ifi.hase.soprafs26.entity.User;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.JoinSessionDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionPutDTO;
-
-import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.hasSize;
@@ -30,10 +27,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SongsControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SongsControllerTest.java
@@ -21,8 +21,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SongsControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SongsControllerTest.java
@@ -2,8 +2,8 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
+import ch.uzh.ifi.hase.soprafs26.service.SessionService;
 import ch.uzh.ifi.hase.soprafs26.service.SongService;
-import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -36,7 +36,7 @@ class SongsControllerTest {
     private SongService songService;
 
     @MockitoBean
-    private UserService userService;
+    private SessionService sessionService;
 
     @Test
     void songsSearch_validQuery_returns200WithResults() throws Exception {
@@ -168,6 +168,29 @@ class SongsControllerTest {
         mockMvc.perform(delete("/sessions/42/songs/7")
                         .header("token", "admin-token"))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void nextSong_adminToken_returns204AndAdvances() throws Exception {
+        willDoNothing().given(sessionService).verifyIsAdmin(42L, "admin-token");
+        willDoNothing().given(songService).nextSong(42L);
+
+        mockMvc.perform(post("/sessions/42/songs/next")
+                        .header("token", "admin-token"))
+                .andExpect(status().isNoContent());
+
+        verify(sessionService).verifyIsAdmin(42L, "admin-token");
+        verify(songService).nextSong(42L);
+    }
+
+    @Test
+    void nextSong_notAdmin_returns403() throws Exception {
+        willThrow(new ResponseStatusException(FORBIDDEN, "Only the session admin can perform this action"))
+                .given(sessionService).verifyIsAdmin(eq(42L), any());
+
+        mockMvc.perform(post("/sessions/42/songs/next")
+                        .header("token", "intruder-token"))
+                .andExpect(status().isForbidden());
     }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SongsControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SongsControllerTest.java
@@ -3,6 +3,7 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.service.SongService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -35,6 +36,9 @@ class SongsControllerTest {
 
     @MockitoBean
     private SongService songService;
+
+    @MockitoBean
+    private UserService userService;
 
     @Test
     void songsSearch_validQuery_returns200WithResults() throws Exception {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UsersControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UsersControllerTest.java
@@ -141,7 +141,8 @@ class UsersControllerTest {
     private String asJsonString(final Object object) {
         try {
             return new ObjectMapper().writeValueAsString(object);
-        } catch (JacksonException e) {
+        }
+        catch (JacksonException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                     String.format("The request body could not be created.%s", e));
         }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/VotingControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/VotingControllerTest.java
@@ -5,6 +5,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.VotingRound;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.VotePostDTO;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import ch.uzh.ifi.hase.soprafs26.service.VotingService;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,7 @@ import tools.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -27,6 +29,8 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @WebMvcTest(VotingController.class)
 class VotingControllerTest {
@@ -237,6 +241,49 @@ class VotingControllerTest {
 
         verify(votingService).getVotingRound(99L, 50L);
         verify(votingService, never()).getVoteCounts(any());
+    }
+
+    @Test
+    void getVotingRounds_noRounds_returns200WithEmptyArray() throws Exception {
+        given(votingService.getRoundsForSession(10L)).willReturn(List.of());
+
+        mockMvc.perform(get("/sessions/10/votingRounds")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+
+        verify(votingService).getRoundsForSession(10L);
+    }
+
+    @Test
+    void getVotingRounds_multipleRounds_returns200WithList() throws Exception {
+        VotingRoundGetDTO dto1 = new VotingRoundGetDTO();
+        dto1.setId(40L);
+        VotingRoundGetDTO dto2 = new VotingRoundGetDTO();
+        dto2.setId(50L);
+
+        given(votingService.getRoundsForSession(10L)).willReturn(List.of(dto1, dto2));
+
+        mockMvc.perform(get("/sessions/10/votingRounds")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(40))
+                .andExpect(jsonPath("$[1].id").value(50));
+
+        verify(votingService).getRoundsForSession(10L);
+    }
+
+    @Test
+    void getVotingRounds_sessionNotFound_returns404() throws Exception {
+        given(votingService.getRoundsForSession(999L))
+                .willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found"));
+
+        mockMvc.perform(get("/sessions/999/votingRounds")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+
+        verify(votingService).getRoundsForSession(999L);
     }
 
     private String asJsonString(final Object object) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/VotingControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/VotingControllerTest.java
@@ -3,9 +3,9 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.entity.VotingRound;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.VotePostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import ch.uzh.ifi.hase.soprafs26.service.VotingService;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,17 +20,15 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(VotingController.class)
 class VotingControllerTest {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/dto/RestDTOTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/dto/RestDTOTest.java
@@ -6,7 +6,6 @@ import ch.uzh.ifi.hase.soprafs26.constant.VotingStatus;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -44,8 +43,8 @@ class RestDTOTest {
         assertEquals(a, a);
         assertEquals(a, b);
         assertNotEquals(a, c);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());
@@ -100,8 +99,8 @@ class RestDTOTest {
         assertEquals(a, a);
         assertEquals(a, b);
         assertNotEquals(a, c);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());
@@ -136,8 +135,8 @@ class RestDTOTest {
 
         assertEquals(a, a);
         assertEquals(a, b);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());
@@ -173,8 +172,8 @@ class RestDTOTest {
         assertEquals(a, a);
         assertEquals(a, b);
         assertNotEquals(a, c);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());
@@ -218,8 +217,8 @@ class RestDTOTest {
 
         assertEquals(a, a);
         assertEquals(a, b);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());
@@ -237,8 +236,8 @@ class RestDTOTest {
 
         assertEquals(a, a);
         assertEquals(a, b);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());
@@ -284,8 +283,8 @@ class RestDTOTest {
 
         assertEquals(a, a);
         assertEquals(a, b);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());
@@ -321,8 +320,8 @@ class RestDTOTest {
 
         assertEquals(a, a);
         assertEquals(a, b);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());
@@ -358,8 +357,8 @@ class RestDTOTest {
 
         assertEquals(a, a);
         assertEquals(a, b);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());
@@ -380,8 +379,8 @@ class RestDTOTest {
         assertEquals(a, a);
         assertEquals(a, b);
         assertNotEquals(a, c);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());
@@ -417,8 +416,8 @@ class RestDTOTest {
 
         assertEquals(a, a);
         assertEquals(a, b);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());
@@ -436,8 +435,8 @@ class RestDTOTest {
         assertEquals(a, a);
         assertEquals(a, b);
         assertNotEquals(a, c);
-        assertNotEquals(a, null);
-        assertNotEquals(a, new Object());
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
         assertEquals(a.hashCode(), b.hashCode());
 
         assertNotNull(a.toString());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -2,12 +2,13 @@ package ch.uzh.ifi.hase.soprafs26.service;
 
 import ch.uzh.ifi.hase.soprafs26.constant.SessionStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
+import ch.uzh.ifi.hase.soprafs26.entity.Song;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
 import ch.uzh.ifi.hase.soprafs26.websocket.SessionWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
-import ch.uzh.ifi.hase.soprafs26.entity.Song;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,12 +20,8 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.Optional;
 import java.util.Set;
 
-import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
-
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,7 +35,7 @@ class SessionServiceTest {
 
     @Mock
     private SongService songService;
-  
+
     @Mock
     private SessionWebSocketPublisher sessionWebSocketPublisher;
 
@@ -378,7 +375,7 @@ class SessionServiceTest {
 
         assertEquals(404, ex.getStatusCode().value());
     }
-  
+
     @Test
     void updateSessionStatus_createdToActive_callsPromoteNextSongAndPersistsActive() {
         session.setStatus(SessionStatus.CREATED);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -19,13 +19,13 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.Optional;
 import java.util.Set;
 
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-
-import static org.mockito.ArgumentMatchers.anyList;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
 
 @ExtendWith(MockitoExtension.class)
 class SessionServiceTest {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -20,8 +20,8 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class SessionServiceTest {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -23,6 +23,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyList;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
+
 @ExtendWith(MockitoExtension.class)
 class SessionServiceTest {
 
@@ -356,5 +360,40 @@ class SessionServiceTest {
                 () -> sessionService.getParticipants(99L));
 
         assertEquals(404, ex.getStatusCode().value());
+    }
+
+
+    @Test
+    void updateSessionStatus_broadcastsStatusViaWebSocket() {
+        session.setStatus(SessionStatus.CREATED);
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.updateSessionStatus(10L, SessionStatus.ACTIVE, admin.getId());
+
+        verify(sessionWebSocketPublisher).broadcastSessionStatus(eq(10L), any(SessionGetDTO.class));
+    }
+
+    @Test
+    void joinSession_broadcastsParticipantsViaWebSocket() {
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.joinSession(10L, "482910", 2L);
+
+        verify(sessionWebSocketPublisher).broadcastParticipants(eq(10L), anyList());
+    }
+
+    @Test
+    void leaveSession_broadcastsParticipantsViaWebSocket() {
+        session.addParticipant(participant);
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.leaveSession(10L, 2L);
+
+        verify(sessionWebSocketPublisher).broadcastParticipants(eq(10L), anyList());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -6,6 +6,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.SessionWebSocketPublisher;
+import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.entity.Song;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,9 @@ class SessionServiceTest {
   
     @Mock
     private SessionWebSocketPublisher sessionWebSocketPublisher;
+
+    @Mock
+    private SongWebSocketPublisher songWebSocketPublisher;
 
     @InjectMocks
     private SessionService sessionService;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(MockitoExtension.class)
 class SessionServiceTest {
@@ -32,7 +33,7 @@ class SessionServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private SongWebSocketPublisher songWebSocketPublisher;
+    private SongService songService;
 
     @InjectMocks
     private SessionService sessionService;
@@ -352,5 +353,17 @@ class SessionServiceTest {
                 () -> sessionService.getParticipants(99L));
 
         assertEquals(404, ex.getStatusCode().value());
+    }
+
+    @Test
+    void updateSessionStatus_createdToActive_callsPromoteNextSongAndPersistsActive() {
+        session.setStatus(SessionStatus.CREATED);
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        Session result = sessionService.updateSessionStatus(10L, SessionStatus.ACTIVE, 1L);
+
+        assertEquals(SessionStatus.ACTIVE, result.getStatus());
+        verify(songService, times(1)).promoteNextSong(eq(10L), eq(session));
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -5,7 +5,6 @@ import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
-import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.websocket.SessionWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.entity.Song;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +23,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyList;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
 
@@ -36,9 +34,6 @@ class SessionServiceTest {
 
     @Mock
     private UserRepository userRepository;
-
-    @Mock
-    private SongWebSocketPublisher songWebSocketPublisher;
 
     @Mock
     private SongService songService;
@@ -183,8 +178,22 @@ class SessionServiceTest {
                 () -> sessionService.joinSession(10L, "000000", 2L));
 
         assertEquals(400, ex.getStatusCode().value());
+        assert ex.getReason() != null;
         assertTrue(ex.getReason().toLowerCase().contains("invalid game pin"));
         // Must not proceed to user lookup or save when PIN is wrong
+        verify(userRepository, never()).findById(any());
+        verify(sessionRepository, never()).save(any());
+    }
+
+    @Test
+    void joinSession_endedSession_throwsNotFound() {
+        session.setStatus(SessionStatus.ENDED);
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> sessionService.joinSession(10L, "482910", 2L));
+
+        assertEquals(404, ex.getStatusCode().value());
         verify(userRepository, never()).findById(any());
         verify(sessionRepository, never()).save(any());
     }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -266,6 +266,13 @@ class SessionServiceTest {
         session.addParticipant(participant);
         session.setStatus(SessionStatus.ACTIVE);
 
+        // Participant already contributed a song before the session started
+        Song contributed = new Song();
+        contributed.setId(501L);
+        contributed.setAddedBy(participant);
+        contributed.setSession(session);
+        session.addSong(contributed);
+
         when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
         when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
         when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
@@ -273,7 +280,7 @@ class SessionServiceTest {
         sessionService.joinSession(10L, "482910", 2L);
 
         assertFalse(session.isPendingInitialSong(participant),
-                "Rejoin after the session has started must NOT re-flag pendingInitialSong");
+                "Rejoin after the session has started must NOT re-flag pendingInitialSong if song was already contributed");
     }
 
     // leaveSession

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -6,6 +6,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
+import ch.uzh.ifi.hase.soprafs26.websocket.SessionWebSocketPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +33,9 @@ class SessionServiceTest {
 
     @Mock
     private SongWebSocketPublisher songWebSocketPublisher;
+
+    @Mock
+    private SessionWebSocketPublisher sessionWebSocketPublisher;
 
     @InjectMocks
     private SessionService sessionService;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -6,6 +6,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SessionRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
+import ch.uzh.ifi.hase.soprafs26.entity.Song;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -198,6 +199,60 @@ class SessionServiceTest {
         verify(sessionRepository, never()).save(any());
     }
 
+    @Test
+    void joinSession_rejoinBeforeAddingSong_reAddsToPendingInitialSong() {
+        session.addParticipant(participant);
+        assertFalse(session.isPendingInitialSong(participant),
+                "Pre-condition: participant should not yet be flagged as pending");
+        assertTrue(session.getPlaylist().isEmpty(),
+                "Pre-condition: participant has not contributed a song");
+        assertEquals(SessionStatus.CREATED, session.getStatus(),
+                "Pre-condition: session is still in lobby phase");
+
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.joinSession(10L, "482910", 2L);
+
+        assertTrue(session.isPendingInitialSong(participant),
+                "Rejoin without a contributed song must re-add the user to pendingInitialSong");
+    }
+
+    @Test
+    void joinSession_rejoinAfterAddingSong_doesNotReAddToPendingInitialSong() {
+        session.addParticipant(participant);
+
+        Song contributed = new Song();
+        contributed.setId(500L);
+        contributed.setAddedBy(participant);
+        contributed.setSession(session);
+        session.addSong(contributed);
+
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.joinSession(10L, "482910", 2L);
+
+        assertFalse(session.isPendingInitialSong(participant),
+                "Rejoin after a contributed song must NOT re-add the user to pendingInitialSong");
+    }
+
+    @Test
+    void joinSession_rejoinAfterSessionStarted_doesNotReAddToPendingInitialSong() {
+        session.addParticipant(participant);
+        session.setStatus(SessionStatus.ACTIVE);
+
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.joinSession(10L, "482910", 2L);
+
+        assertFalse(session.isPendingInitialSong(participant),
+                "Rejoin after the session has started must NOT re-flag pendingInitialSong");
+    }
 
     // leaveSession
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -33,6 +33,9 @@ class SessionServiceTest {
     private UserRepository userRepository;
 
     @Mock
+    private SongWebSocketPublisher songWebSocketPublisher;
+
+    @Mock
     private SongService songService;
 
     @InjectMocks

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -360,12 +360,6 @@ class SongServiceTest {
         songService.deleteSongFromQueue(1L, 10L, "test-token");
 
         verify(votingService, times(1)).createVotingRound(1L);
-        verify(songWebSocketPublisher).broadcastQueue(eq(1L), argThat(queue ->
-                queue != null
-                        && queue.size() == 2
-                        && queue.stream().map(SongGetDTO::getTitle).noneMatch("Current Song"::equals)
-                        && queue.stream().map(SongGetDTO::getTitle).anyMatch("Song 2"::equals)
-                        && queue.stream().map(SongGetDTO::getTitle).anyMatch("Song 3"::equals)));
         verify(songWebSocketPublisher, never()).broadcastCurrentSong(anyLong(), any());
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -9,7 +9,6 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.SongPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongSearchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.websocket.SongWebSocketPublisher;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -249,7 +248,6 @@ class SongServiceTest {
     }
 
     @Test
-    @Disabled("Deferred until nextSong() refactoring in the next ticket")
     void deleteSongFromQueue_success_removesQueuedSongAndBroadcasts() {
         User admin = new User();
         admin.setId(1L);
@@ -289,7 +287,6 @@ class SongServiceTest {
     }
 
     @Test
-    @Disabled("Deferred until nextSong() refactoring in the next ticket")
     void deleteSongFromQueue_success_deletesCurrentSongAndBroadcastsNew() {
         User admin = new User();
         admin.setId(1L);
@@ -327,8 +324,7 @@ class SongServiceTest {
     }
 
     @Test
-    @Disabled("Deferred until nextSong() refactoring in the next ticket")
-    void deleteSongFromQueue_deletesCurrentSong_multipleRemaining_broadcastsNullCurrentSong() {
+    void deleteSongFromQueue_deletesCurrentSong_multipleRemaining_opensVotingRound() {
         User admin = new User();
         admin.setId(1L);
 
@@ -363,13 +359,11 @@ class SongServiceTest {
 
         songService.deleteSongFromQueue(1L, 10L, "test-token");
 
-        // 2+ songs remain — broadcast null current song (voting round TODO)
-        verify(songWebSocketPublisher).broadcastCurrentSong(eq(1L), isNull());
-        verify(songWebSocketPublisher).broadcastQueue(eq(1L), argThat(list -> list.size() == 2));
+        verify(votingService, times(1)).createVotingRound(1L);
+        verify(songWebSocketPublisher, never()).broadcastCurrentSong(anyLong(), any());
     }
 
     @Test
-    @Disabled("Deferred until nextSong() refactoring in the next ticket")
     void deleteSongFromQueue_deletesCurrentSong_noneRemaining_broadcastsNull() {
         User admin = new User();
         admin.setId(1L);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -360,6 +360,12 @@ class SongServiceTest {
         songService.deleteSongFromQueue(1L, 10L, "test-token");
 
         verify(votingService, times(1)).createVotingRound(1L);
+        verify(songWebSocketPublisher).broadcastQueue(eq(1L), argThat(queue ->
+                queue != null
+                        && queue.size() == 2
+                        && queue.stream().map(SongGetDTO::getTitle).noneMatch("Current Song"::equals)
+                        && queue.stream().map(SongGetDTO::getTitle).anyMatch("Song 2"::equals)
+                        && queue.stream().map(SongGetDTO::getTitle).anyMatch("Song 3"::equals)));
         verify(songWebSocketPublisher, never()).broadcastCurrentSong(anyLong(), any());
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -22,11 +22,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.*;
 
 class SongServiceTest {
 
@@ -189,9 +185,12 @@ class SongServiceTest {
         Session session = new Session();
         session.setId(1L);
 
-        Song current = new Song(); current.setPerformed(false);
-        Song song1 = new Song(); song1.setPerformed(false);
-        Song song2 = new Song(); song2.setPerformed(false);
+        Song current = new Song();
+        current.setPerformed(false);
+        Song song1 = new Song();
+        song1.setPerformed(false);
+        Song song2 = new Song();
+        song2.setPerformed(false);
         session.getPlaylist().addAll(List.of(current, song1, song2));
 
         when(sessionService.getSessionById(1L)).thenReturn(session);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -442,7 +443,7 @@ class SongServiceTest {
 
         when(sessionService.getSessionById(5L)).thenReturn(session);
 
-        songService.broadcastVotingRoundSongWinner(5L, winner);
+        songService.broadcastVotingRoundSongWinner(5L, winner, Collections.emptyMap());
 
         verify(songWebSocketPublisher).broadcastCurrentSong(eq(5L), argThat(dto -> dto != null && "Winner Song".equals(dto.getTitle())));
         verify(songWebSocketPublisher).broadcastQueue(eq(5L), argThat(list -> list.size() == 1));

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -7,7 +7,6 @@ import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.VotingRoundRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.VotingWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -120,11 +119,12 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
 
         assertDoesNotThrow(() -> votingService.castVote(10L, 50L, 100L, voter));
 
-        verify(voteRepository, times(1)).save(any(Vote.class));
+        verify(voteRepository, times(1)).saveAndFlush(any(Vote.class));
     }
 
     // Check fields correctly set in vote
@@ -134,11 +134,11 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
 
         votingService.castVote(10L, 50L, 100L, voter);
 
-        verify(voteRepository).save(argThat(vote ->
+        verify(voteRepository).saveAndFlush(argThat(vote ->
                 vote.getVotingRound().equals(votingRound) &&
                         vote.getVoter().equals(voter) &&
                         vote.getVotedSong().equals(candidateSong)
@@ -156,7 +156,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 99L, 100L, voter));
 
         assertEquals(404, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -170,7 +170,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(999L, 50L, 100L, voter));
 
         assertEquals(400, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -185,7 +185,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, voter));
 
         assertEquals(410, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -199,7 +199,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, nonParticipant));
 
         assertEquals(403, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -214,7 +214,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 999L, voter));
 
         assertEquals(404, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -229,7 +229,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 200L, voter));
 
         assertEquals(400, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 
@@ -245,7 +245,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, voter));
 
         assertEquals(409, ex.getStatusCode().value());
-        verify(voteRepository, never()).save(any());
+        verify(voteRepository, never()).saveAndFlush(any());
     }
 
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -120,12 +120,11 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
-        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
+        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
 
         assertDoesNotThrow(() -> votingService.castVote(10L, 50L, 100L, voter));
 
-        verify(voteRepository, times(1)).saveAndFlush(any(Vote.class));
+        verify(voteRepository, times(1)).save(any(Vote.class));
     }
 
     // Check fields correctly set in vote
@@ -135,12 +134,11 @@ class VotingServiceTest {
         when(votingRoundRepository.findById(50L)).thenReturn(Optional.of(votingRound));
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
-        when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
-        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
+        when(voteRepository.save(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
 
         votingService.castVote(10L, 50L, 100L, voter);
 
-        verify(voteRepository).saveAndFlush(argThat(vote ->
+        verify(voteRepository).save(argThat(vote ->
                 vote.getVotingRound().equals(votingRound) &&
                         vote.getVoter().equals(voter) &&
                         vote.getVotedSong().equals(candidateSong)
@@ -158,7 +156,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 99L, 100L, voter));
 
         assertEquals(404, ex.getStatusCode().value());
-        verify(voteRepository, never()).saveAndFlush(any());
+        verify(voteRepository, never()).save(any());
     }
 
 
@@ -172,7 +170,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(999L, 50L, 100L, voter));
 
         assertEquals(400, ex.getStatusCode().value());
-        verify(voteRepository, never()).saveAndFlush(any());
+        verify(voteRepository, never()).save(any());
     }
 
 
@@ -187,7 +185,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, voter));
 
         assertEquals(410, ex.getStatusCode().value());
-        verify(voteRepository, never()).saveAndFlush(any());
+        verify(voteRepository, never()).save(any());
     }
 
 
@@ -201,7 +199,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 100L, nonParticipant));
 
         assertEquals(403, ex.getStatusCode().value());
-        verify(voteRepository, never()).saveAndFlush(any());
+        verify(voteRepository, never()).save(any());
     }
 
 
@@ -216,7 +214,7 @@ class VotingServiceTest {
                 () -> votingService.castVote(10L, 50L, 999L, voter));
 
         assertEquals(404, ex.getStatusCode().value());
-        verify(voteRepository, never()).saveAndFlush(any());
+        verify(voteRepository, never()).save(any());
     }
 
 
@@ -393,6 +391,62 @@ class VotingServiceTest {
 
         verify(votingRoundRepository, never()).save(any());
         verify(songService, never()).broadcastVotingRoundSongWinner(any(), any());
+    }
+
+    @Test
+    void getRoundsForSession_noRounds_returnsEmptyList() {
+        when(sessionService.getSessionById(10L)).thenReturn(session);
+        when(votingRoundRepository.findBySessionOrderByStartsAtAsc(session))
+                .thenReturn(List.of());
+
+        List<VotingRoundGetDTO> result = votingService.getRoundsForSession(10L);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(voteRepository, never()).countVotesPerSong(any());
+    }
+
+    @Test
+    void getRoundsForSession_multipleRounds_returnsAllOrderedWithCounts() {
+        VotingRound earlier = new VotingRound();
+        earlier.setId(40L);
+        earlier.setSession(session);
+        earlier.setStatus(VotingStatus.CLOSED);
+        earlier.setStartsAt(LocalDateTime.now().minusMinutes(5));
+        earlier.setEndsAt(LocalDateTime.now().minusMinutes(4));
+        earlier.getCandidates().add(candidateSong);
+
+        when(sessionService.getSessionById(10L)).thenReturn(session);
+        when(votingRoundRepository.findBySessionOrderByStartsAtAsc(session))
+                .thenReturn(List.of(earlier, votingRound));
+
+        VoteRepository.SongVoteCount earlierCount = mock(VoteRepository.SongVoteCount.class);
+        when(earlierCount.getSongId()).thenReturn(100L);
+        when(earlierCount.getCount()).thenReturn(3L);
+        when(voteRepository.countVotesPerSong(earlier)).thenReturn(List.of(earlierCount));
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
+
+        List<VotingRoundGetDTO> result = votingService.getRoundsForSession(10L);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(40L, result.get(0).getId());
+        assertEquals(50L, result.get(1).getId());
+        verify(voteRepository, times(1)).countVotesPerSong(earlier);
+        verify(voteRepository, times(1)).countVotesPerSong(votingRound);
+    }
+
+    @Test
+    void getRoundsForSession_sessionNotFound_throwsNotFound() {
+        when(sessionService.getSessionById(999L))
+                .thenThrow(new ResponseStatusException(
+                        org.springframework.http.HttpStatus.NOT_FOUND, "Session not found"));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> votingService.getRoundsForSession(999L));
+
+        assertEquals(404, ex.getStatusCode().value());
+        verify(votingRoundRepository, never()).findBySessionOrderByStartsAtAsc(any());
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -402,7 +402,7 @@ class VotingServiceTest {
     @Test
     void getRoundsForSession_noRounds_returnsEmptyList() {
         when(sessionService.getSessionById(10L)).thenReturn(session);
-        when(votingRoundRepository.findBySessionOrderByStartsAtAsc(session))
+        when(votingRoundRepository.findBySessionWithCandidatesOrderByStartsAtAsc(session))
                 .thenReturn(List.of());
 
         List<VotingRoundGetDTO> result = votingService.getRoundsForSession(10L);
@@ -423,7 +423,7 @@ class VotingServiceTest {
         earlier.getCandidates().add(candidateSong);
 
         when(sessionService.getSessionById(10L)).thenReturn(session);
-        when(votingRoundRepository.findBySessionOrderByStartsAtAsc(session))
+        when(votingRoundRepository.findBySessionWithCandidatesOrderByStartsAtAsc(session))
                 .thenReturn(List.of(earlier, votingRound));
 
         VoteRepository.SongVoteCount earlierCount = mock(VoteRepository.SongVoteCount.class);
@@ -452,7 +452,7 @@ class VotingServiceTest {
                 () -> votingService.getRoundsForSession(999L));
 
         assertEquals(404, ex.getStatusCode().value());
-        verify(votingRoundRepository, never()).findBySessionOrderByStartsAtAsc(any());
+        verify(votingRoundRepository, never()).findBySessionWithCandidatesOrderByStartsAtAsc(any());
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -7,6 +7,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.VotingRoundRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.VotingWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -338,7 +338,7 @@ class VotingServiceTest {
         when(sessionService.getSessionById(10L)).thenReturn(session);
         votingService.createVotingRound(10L);
 
-        verify(songService, times(1)).broadcastVotingRoundSongWinner(eq(10L), eq(candidateSong));
+        verify(songService, times(1)).broadcastVotingRoundSongWinner(eq(10L), eq(candidateSong), any());
         verify(votingRoundRepository, never()).save(any());
         verify(votingWebSocketPublisher, never()).broadcastVotingRound(anyLong(), any());
         verify(taskScheduler, never()).schedule(any(Runnable.class), any(Instant.class));
@@ -385,7 +385,7 @@ class VotingServiceTest {
         assertEquals(VotingStatus.CLOSED, votingRound.getStatus());
         verify(votingRoundRepository, times(1)).save(votingRound);
 
-        verify(songService, times(1)).broadcastVotingRoundSongWinner(eq(10L), eq(candidateSong));
+        verify(songService, times(1)).broadcastVotingRoundSongWinner(eq(10L), eq(candidateSong), any());
     }
 
     @Test
@@ -396,7 +396,7 @@ class VotingServiceTest {
         votingService.finishVotingRoundAndPlayNextSong(10L, 50L);
 
         verify(votingRoundRepository, never()).save(any());
-        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any());
+        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any(), any());
     }
 
     @Test
@@ -505,7 +505,7 @@ class VotingServiceTest {
 
         votingService.createVotingRound(10L);
 
-        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any());
+        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any(), any());
         verify(votingRoundRepository, never()).save(any());
         verify(votingWebSocketPublisher, never()).broadcastVotingRound(anyLong(), any());
         verify(taskScheduler, never()).schedule(any(Runnable.class), any(Instant.class));
@@ -520,7 +520,7 @@ class VotingServiceTest {
 
         votingService.createVotingRound(10L);
 
-        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any());
+        verify(songService, never()).broadcastVotingRoundSongWinner(any(), any(), any());
         verify(votingRoundRepository, never()).save(any());
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -136,6 +136,7 @@ class VotingServiceTest {
         when(songRepository.findById(100L)).thenReturn(Optional.of(candidateSong));
         when(voteRepository.existsByVotingRoundAndVoter(votingRound, voter)).thenReturn(false);
         when(voteRepository.saveAndFlush(any(Vote.class))).thenAnswer(i -> i.getArgument(0));
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of());
 
         votingService.castVote(10L, 50L, 100L, voter);
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -5,9 +5,9 @@ import ch.uzh.ifi.hase.soprafs26.entity.*;
 import ch.uzh.ifi.hase.soprafs26.repository.SongRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.VotingRoundRepository;
-import ch.uzh.ifi.hase.soprafs26.websocket.VotingWebSocketPublisher;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.VotingRoundGetDTO;
+import ch.uzh.ifi.hase.soprafs26.websocket.VotingWebSocketPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,14 +15,14 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.context.ApplicationContext;
 
-import java.time.LocalDateTime;
 import java.time.Instant;
-import java.util.List;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SessionWebSocketPublisherImplTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SessionWebSocketPublisherImplTest.java
@@ -1,0 +1,38 @@
+package ch.uzh.ifi.hase.soprafs26.websocket;
+
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SessionWebSocketPublisherImplTest {
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private SessionWebSocketPublisherImpl publisher;
+
+    @Test
+    void broadcastSessionStatus_sendsToCorrectTopic() {
+        SessionGetDTO dto = new SessionGetDTO();
+        publisher.broadcastSessionStatus(42L, dto);
+        verify(messagingTemplate).convertAndSend("/topic/sessions/42/status", dto);
+    }
+
+    @Test
+    void broadcastParticipants_sendsToCorrectTopic() {
+        List<UserGetDTO> participants = List.of(new UserGetDTO());
+        publisher.broadcastParticipants(42L, participants);
+        verify(messagingTemplate).convertAndSend("/topic/sessions/42/participants", participants);
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImplTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImplTest.java
@@ -8,11 +8,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,20 +39,29 @@ class SongWebSocketPublisherImplTest {
     }
 
     @Test
-    void broadcastCurrentSong_sendsToCorrectTopic() {
+    void broadcastCurrentSong_sendsWrappedPayload() {
         SongGetDTO song = new SongGetDTO();
         song.setTitle("Current Song");
+        ArgumentCaptor<CurrentSongPayload> captor = ArgumentCaptor.forClass(CurrentSongPayload.class);
 
         publisher.broadcastCurrentSong(1L, song);
 
-        verify(messagingTemplate).convertAndSend("/topic/sessions/1/currentSong", song);
+        verify(messagingTemplate).convertAndSend(
+                eq("/topic/sessions/1/currentSong"),
+                captor.capture());
+        assertEquals("Current Song", captor.getValue().getSong().getTitle());
     }
 
     @Test
-    void broadcastCurrentSong_withNullSong_sendsNullPayload() {
+    void broadcastCurrentSong_withNullSong_sendsWrappedNull() {
+        ArgumentCaptor<CurrentSongPayload> captor = ArgumentCaptor.forClass(CurrentSongPayload.class);
+
         publisher.broadcastCurrentSong(1L, null);
 
-        verify(messagingTemplate).convertAndSend("/topic/sessions/1/currentSong", (Object) null);
+        verify(messagingTemplate).convertAndSend(
+                eq("/topic/sessions/1/currentSong"),
+                captor.capture());
+        assertNull(captor.getValue().getSong());
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImplTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImplTest.java
@@ -12,7 +12,6 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImplTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImplTest.java
@@ -12,8 +12,8 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImplTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/SongWebSocketPublisherImplTest.java
@@ -8,7 +8,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 


### PR DESCRIPTION
This pull request introduces several key improvements to the session and song management logic, enhances real-time updates via WebSockets, and refines the voting system. The changes ensure better synchronization of session state across clients, robust authentication, and improved data modeling for songs and voting rounds.

**Session and Song Management Enhancements:**

* Songs now track when they are played with a new `playedAt` timestamp, and the `markPerformed()` method updates both the performed status and timestamp (`Song.java`). [[1]](diffhunk://#diff-0bb431cd042834c782bc8619731cc22edc1b9730fe6ed6d284138bc13e1f04a1R43-R45) [[2]](diffhunk://#diff-0bb431cd042834c782bc8619731cc22edc1b9730fe6ed6d284138bc13e1f04a1R57)
* When the session status transitions from `CREATED` to `ACTIVE`, the next song is automatically promoted, and session status updates are broadcast via WebSocket (`SessionService.java`).
* When users join or leave a session, the updated participant list is broadcast to all clients, ensuring real-time synchronization (`SessionService.java`). [[1]](diffhunk://#diff-9e895e86815be3a850840785d3f0686b8c5973b00c3a2b9ee54c61b87abca723R189-R202) [[2]](diffhunk://#diff-9e895e86815be3a850840785d3f0686b8c5973b00c3a2b9ee54c61b87abca723L204-R233)
* The logic for promoting the next song in the queue has been refactored and reused in multiple places, ensuring consistent song advancement and notifications (`SongService.java`). [[1]](diffhunk://#diff-843b2a0ff682f99ed650f11c6640b7f4a5784bd1cd3a768ada305d671ea368bcR107-R113) [[2]](diffhunk://#diff-843b2a0ff682f99ed650f11c6640b7f4a5784bd1cd3a768ada305d671ea368bcR167-R206)

**WebSocket and API Improvements:**

* Introduced the `CurrentSongPayload` wrapper for broadcasting the current song, updating both backend and API documentation to use this format. This ensures clients always receive a consistent payload, even when there is no current song (`CurrentSongPayload.java`, `SongWebSocketPublisherImpl.java`, `karaokee-asyncapi.yaml`). [[1]](diffhunk://#diff-aa7d4bb5894ff4873109718454a16c7c6d93a824d3e738e1adf6a2abd8921116R1-R22) [[2]](diffhunk://#diff-b7ab00c6c32582fdffb4574007cabaaf6d9bc7b2663690893a7772fbba07905bL27-R28) [[3]](diffhunk://#diff-1dd9c279cd88b50da42a44dbd6c3fde7c6629e2eabbbd3a846439eeaccd6c6f4R30-R31) [[4]](diffhunk://#diff-1dd9c279cd88b50da42a44dbd6c3fde7c6629e2eabbbd3a846439eeaccd6c6f4L155-R157) [[5]](diffhunk://#diff-1dd9c279cd88b50da42a44dbd6c3fde7c6629e2eabbbd3a846439eeaccd6c6f4R233-R245)
* Added a new `SessionWebSocketPublisherImpl` to broadcast session status and participant changes, improving real-time session state updates (`SessionWebSocketPublisherImpl.java`).

**Voting System Improvements:**

* Implemented retrieval of all voting rounds for a session and exposed this via the API (`VotingController.java`, `VotingService.java`). [[1]](diffhunk://#diff-1013b2a67fd0518695a51110db3e488a882bdb834714a92f61e73904b1b44003L36-R36) [[2]](diffhunk://#diff-ecefdadb4cdb0fbbac3ac38624b1db1e52f9bb8b1a8de67b115cd95d44c0b680R220-R236)
* Added repository methods to fetch voting rounds in order and to remove song candidates efficiently, supporting robust voting round management (`VotingRoundRepository.java`). [[1]](diffhunk://#diff-f95e538f03af64ff5714ccbad435a3539d62fb49678fcfd5957aa99b14e9e85dR20-R24) [[2]](diffhunk://#diff-f95e538f03af64ff5714ccbad435a3539d62fb49678fcfd5957aa99b14e9e85dR7) [[3]](diffhunk://#diff-f95e538f03af64ff5714ccbad435a3539d62fb49678fcfd5957aa99b14e9e85dR20-R24)

**Security and Data Consistency:**

* The endpoint for skipping to the next song now requires authentication, improving security for session actions (`SongsController.java`).

**Testing and Minor Cleanups:**

* Updated tests and minor code cleanups to support new DTOs and ensure correctness (`VotingControllerTest.java`). [[1]](diffhunk://#diff-286bff14b4e004e37c18b6566fca716c3853136dc827535982cde29aa170d6b8R8) [[2]](diffhunk://#diff-286bff14b4e004e37c18b6566fca716c3853136dc827535982cde29aa170d6b8R24-R33)
* Commented out the line that nullifies a song's session reference on removal, possibly to avoid unintended side effects (`Session.java`).

Let me know if you have questions about any specific part of these changes!