### PR TITLE
Bugfix: Rejoin logic

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -173,7 +173,7 @@ public class SessionService {
         // Set.add() is a no-op when user is already present → idempotent
         session.addParticipant(user);
 
-        if (session.getStatus() == SessionStatus.CREATED || session.getStatus() == SessionStatus.ACTIVE) {
+        if (session.getStatus() != SessionStatus.ENDED) {
             if (hasContributedSong(session, user)) {
                 session.removeFromPendingInitialSong(user);
             } else {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs26.service;
 
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.entity.Song;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.SongRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SongPostDTO;
@@ -92,9 +93,11 @@ public class SongService {
         song.setDurationMs(dto.getDurationMs());
         song.setLyrics(getCachedLyrics(dto.getSpotifyId())); // nullable
         song.setSession(session);
-        song.setAddedBy(userService.getUserByToken(token));
+        User addedBy = userService.getUserByToken(token);
+        song.setAddedBy(addedBy);
         song = songRepository.save(song);
 
+        sessionService.markInitialSongAdded(sessionId, addedBy.getId());
         session.addSong(song); // update in-memory list for broadcast
 
         // Broadcast updated queue (no votes yet → empty counts map)

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SessionServiceTest.java
@@ -283,6 +283,41 @@ class SessionServiceTest {
                 "Rejoin after the session has started must NOT re-flag pendingInitialSong if song was already contributed");
     }
 
+    @Test
+    void joinSession_pausedSession_newUser_addsToPendingInitialSong() {
+        session.setStatus(SessionStatus.PAUSED);
+
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.joinSession(10L, "482910", 2L);
+
+        assertTrue(session.isPendingInitialSong(participant),
+                "A new user joining a PAUSED session must be flagged as pending initial song");
+    }
+
+    @Test
+    void joinSession_pausedSession_userWithContributedSong_doesNotAddToPendingInitialSong() {
+        session.setStatus(SessionStatus.PAUSED);
+        session.addParticipant(participant);
+
+        Song contributed = new Song();
+        contributed.setId(502L);
+        contributed.setAddedBy(participant);
+        contributed.setSession(session);
+        session.addSong(contributed);
+
+        when(sessionRepository.findById(10L)).thenReturn(Optional.of(session));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+        when(sessionRepository.save(any(Session.class))).thenAnswer(i -> i.getArgument(0));
+
+        sessionService.joinSession(10L, "482910", 2L);
+
+        assertFalse(session.isPendingInitialSong(participant),
+                "A user who already contributed a song must NOT be flagged as pending when rejoining a PAUSED session");
+    }
+
     // leaveSession
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -133,6 +133,27 @@ class SongServiceTest {
     }
 
     @Test
+    void addToQueue_callsMarkInitialSongAdded() {
+        User user = new User();
+        user.setId(42L);
+
+        Session session = new Session();
+        SongPostDTO dto = new SongPostDTO("track999", "Bohemian Rhapsody", "Queen", 354000);
+
+        when(sessionService.getSessionById(5L)).thenReturn(session);
+        when(userService.getUserByToken("token")).thenReturn(user);
+        when(songRepository.save(any(Song.class))).thenAnswer(inv -> {
+            Song s = inv.getArgument(0);
+            s.setId(99L);
+            return s;
+        });
+
+        songService.addToQueue(5L, dto, "token");
+
+        verify(sessionService).markInitialSongAdded(5L, 42L);
+    }
+
+    @Test
     void addToQueue_noLyricsCache_persistsSongWithNullLyrics() {
         Session session = new Session();
         SongPostDTO dto = new SongPostDTO("uncached", "Unknown Song", "Unknown", 180000);


### PR DESCRIPTION
This pull request introduces improvements to session handling and song queue management, ensuring better consistency when users join sessions and add songs. The most important changes are:

**Session handling:**

* Updated the logic in `SessionService.joinSession` so that users can join any session that hasn't ended, not just those in `CREATED` or `ACTIVE` status. This makes joining sessions more flexible and robust.

**Song queue management:**

* In `SongService.addToQueue`, after a song is added, the system now explicitly marks that the user has contributed their initial song to the session. This helps keep track of user participation and ensures session state is correctly updated.
* Added the missing import for the `User` entity in `SongService.java`, which is necessary for the new logic involving user participation tracking.