### PR TITLE
Still rejoin bugfix

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/VotingRound.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/VotingRound.java
@@ -49,4 +49,7 @@ public class VotingRound {
     @OneToMany(mappedBy = "votingRound", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Vote> votes = new ArrayList<>();
 
+    @Column
+    private Long winnerId;
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -69,6 +69,7 @@ public interface DTOMapper {
     @Mapping(target = "endsAt", source = "round.endsAt")
     @Mapping(target = "candidates", source = "candidates", qualifiedByName = "candidatesWithVoteCounts")
     @Mapping(target = "roundNumber", ignore = true)
+    @Mapping(target = "winnerId", source = "round.winnerId")
     VotingRoundGetDTO toVotingRoundGetDTO(VotingRound round, @Context Map<Long, Long> counts);
 
     @Mapping(target = "currentVoteCount", expression = "java(counts.getOrDefault(song.getId(), 0L).intValue())")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SessionService.java
@@ -290,18 +290,6 @@ public class SessionService {
         return session.isPendingInitialSong(user);
     }
 
-    public void markInitialSongAdded(Long sessionId, Long userId) {
-        Session session = getSessionById(sessionId);
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, USER_NOT_FOUND));
-        session.removeFromPendingInitialSong(user);
-        sessionRepository.save(session);
-        log.debug("User {} fulfilled initial song requirement for session {}",
-                userId, sessionId);
-    }
-
-
     /**
      * Returns the list of performed songs for a completed session (review screen).
      * Songs are ordered by position (play order)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SongService.java
@@ -97,7 +97,7 @@ public class SongService {
         song.setAddedBy(addedBy);
         song = songRepository.save(song);
 
-        sessionService.markInitialSongAdded(sessionId, addedBy.getId());
+        session.removeFromPendingInitialSong(addedBy);
         session.addSong(song); // update in-memory list for broadcast
 
         // Broadcast updated queue (no votes yet → empty counts map)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/VotingService.java
@@ -202,7 +202,6 @@ public class VotingService {
 
         round.setStatus(VotingStatus.CLOSED);
         round.setEndsAt(LocalDateTime.now(ZoneOffset.UTC));
-        votingRoundRepository.save(round);
 
         Map<Long, Long> finalCounts = getVoteCounts(round);
 
@@ -214,8 +213,10 @@ public class VotingService {
 
         Song votingRoundSongWinner = winnerCandidates.get(random.nextInt(winnerCandidates.size()));
 
+        round.setWinnerId(votingRoundSongWinner.getId());
+        votingRoundRepository.save(round);
+
         VotingRoundGetDTO closedRoundDTO = DTOMapper.INSTANCE.toVotingRoundGetDTO(round, finalCounts);
-        closedRoundDTO.setWinnerId(votingRoundSongWinner.getId());
         votingWebSocketPublisher.broadcastVotingRound(sessionId, closedRoundDTO);
 
         moveWinnerToFrontOfQueue(sessionId, votingRoundSongWinner);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SongServiceTest.java
@@ -133,11 +133,14 @@ class SongServiceTest {
     }
 
     @Test
-    void addToQueue_callsMarkInitialSongAdded() {
+    void addToQueue_removesUserFromPendingInitialSong() {
         User user = new User();
         user.setId(42L);
 
         Session session = new Session();
+        session.addToPendingInitialSong(user);
+        assertTrue(session.isPendingInitialSong(user), "Pre-condition: user must be pending before adding a song");
+
         SongPostDTO dto = new SongPostDTO("track999", "Bohemian Rhapsody", "Queen", 354000);
 
         when(sessionService.getSessionById(5L)).thenReturn(session);
@@ -150,7 +153,7 @@ class SongServiceTest {
 
         songService.addToQueue(5L, dto, "token");
 
-        verify(sessionService).markInitialSongAdded(5L, 42L);
+        assertFalse(session.isPendingInitialSong(user), "User must be removed from pendingInitialSong after adding a song");
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/VotingServiceTest.java
@@ -383,6 +383,8 @@ class VotingServiceTest {
         votingService.finishVotingRoundAndPlayNextSong(10L, 50L);
 
         assertEquals(VotingStatus.CLOSED, votingRound.getStatus());
+        assertEquals(candidateSong.getId(), votingRound.getWinnerId(),
+                "winnerId must be persisted on the entity so the GET endpoint returns it correctly");
         verify(votingRoundRepository, times(1)).save(votingRound);
 
         verify(songService, times(1)).broadcastVotingRoundSongWinner(eq(10L), eq(candidateSong), any());
@@ -552,5 +554,58 @@ class VotingServiceTest {
                 .findFirst()
                 .orElseThrow();
         assertEquals(2, votedSong.getCurrentVoteCount());
+    }
+
+    @Test
+    void getRoundsForSession_closedRound_includesWinnerIdInDTO() {
+        VotingRound closedRound = new VotingRound();
+        closedRound.setId(60L);
+        closedRound.setSession(session);
+        closedRound.setStatus(VotingStatus.CLOSED);
+        closedRound.setStartsAt(LocalDateTime.now().minusMinutes(2));
+        closedRound.setEndsAt(LocalDateTime.now().minusMinutes(1));
+        closedRound.setWinnerId(100L);
+        closedRound.getCandidates().add(candidateSong);
+
+        when(sessionService.getSessionById(10L)).thenReturn(session);
+        when(votingRoundRepository.findBySessionWithCandidatesOrderByStartsAtAsc(session))
+                .thenReturn(List.of(closedRound));
+        when(voteRepository.countVotesPerSong(closedRound)).thenReturn(List.of());
+
+        List<VotingRoundGetDTO> result = votingService.getRoundsForSession(10L);
+
+        assertEquals(1, result.size());
+        assertEquals(100L, result.get(0).getWinnerId(),
+                "GET endpoint must return the persisted winnerId so the frontend shows the correct winner");
+    }
+
+    @Test
+    void finishVotingRound_tiedVotes_picksOneOfTheTiedSongsAsWinner() {
+        Song tiedSong = new Song();
+        tiedSong.setId(300L);
+        tiedSong.setTitle("Tied Song");
+        tiedSong.setPerformed(false);
+        votingRound.getCandidates().add(tiedSong);
+        session.setPlaylist(new ArrayList<>(List.of(candidateSong, tiedSong)));
+
+        when(votingRoundRepository.findByIdWithCandidates(50L)).thenReturn(Optional.of(votingRound));
+        when(sessionService.getSessionById(10L)).thenReturn(session);
+
+        VoteRepository.SongVoteCount count1 = mock(VoteRepository.SongVoteCount.class);
+        when(count1.getSongId()).thenReturn(100L);
+        when(count1.getCount()).thenReturn(3L);
+
+        VoteRepository.SongVoteCount count2 = mock(VoteRepository.SongVoteCount.class);
+        when(count2.getSongId()).thenReturn(300L);
+        when(count2.getCount()).thenReturn(3L);
+
+        when(voteRepository.countVotesPerSong(votingRound)).thenReturn(List.of(count1, count2));
+
+        votingService.finishVotingRoundAndPlayNextSong(10L, 50L);
+
+        assertEquals(VotingStatus.CLOSED, votingRound.getStatus());
+        assertTrue(
+                votingRound.getWinnerId().equals(100L) || votingRound.getWinnerId().equals(300L),
+                "On a tie, one of the tied songs must be selected as winner");
     }
 }


### PR DESCRIPTION
This pull request introduces support for persisting and exposing the winner of a voting round within the system. The changes ensure that the `winnerId` is stored in the database, included in API responses, and properly tested. Additionally, some code cleanup and refactoring were performed to streamline how users are removed from the pending initial song list.

Key changes:

**Voting Round Winner Persistence and Exposure:**

* Added a new `winnerId` field to the `VotingRound` entity to persist the winning song's ID in the database.
* Updated the DTO mapping so that `winnerId` is included in the `VotingRoundGetDTO` returned by the API.
* Modified the voting round completion logic to set and persist the `winnerId` when a round is closed, ensuring the winner is stored and available in subsequent queries. [[1]](diffhunk://#diff-ecefdadb4cdb0fbbac3ac38624b1db1e52f9bb8b1a8de67b115cd95d44c0b680R216-L218) [[2]](diffhunk://#diff-ecefdadb4cdb0fbbac3ac38624b1db1e52f9bb8b1a8de67b115cd95d44c0b680L205)

**Initial Song Requirement Refactoring:**

* Removed the now-unnecessary `markInitialSongAdded` method from `SessionService` and updated the logic to directly remove users from the pending initial song list when they add a song. [[1]](diffhunk://#diff-9e895e86815be3a850840785d3f0686b8c5973b00c3a2b9ee54c61b87abca723L293-L304) [[2]](diffhunk://#diff-843b2a0ff682f99ed650f11c6640b7f4a5784bd1cd3a768ada305d671ea368bcL100-R100)
* Updated and renamed the relevant test to check that users are correctly removed from the pending list after adding a song. [[1]](diffhunk://#diff-ee464a2a6999603cf8dac2a66de11f2a43a4d021beb95c2a9f81c725783fa249L136-R143) [[2]](diffhunk://#diff-ee464a2a6999603cf8dac2a66de11f2a43a4d021beb95c2a9f81c725783fa249L153-R156)

**Testing and Validation:**

* Added and updated tests to verify that `winnerId` is correctly persisted and exposed in the DTOs, including scenarios for closed rounds and tie-breaking logic. [[1]](diffhunk://#diff-0d1787a10f9632640ea88c11ed8c6dc6628a34e776df7c8f890cdcc28ea138eaR386-R387) [[2]](diffhunk://#diff-0d1787a10f9632640ea88c11ed8c6dc6628a34e776df7c8f890cdcc28ea138eaR558-R610)